### PR TITLE
Find chemistry fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ordered-float = "5.0.0"
 #plotly = "0.12.1"
 plotly = { git = "https://github.com/plotly/plotly.rs.git", branch = "main" }
 
-zoe = { version = "0.0.19", default-features = false, features = [
+zoe = { version = "0.0.21", default-features = false, features = [
     "multiversion",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "A set of rusty tools for use in MIRA"
 clap = { version = "4", features = ["derive"] }
 csv = "1.3.1"
 either = "1"
+flate2 = "1.1.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9"
 glob = "0.3.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,3 +59,4 @@ fn main() {
 
 mod processes;
 pub use crate::processes::*;
+pub(crate) mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,10 @@ fn main() {
     let module = module_path!();
 
     match args.command {
-        Commands::VariantsOfInterest(cmd_args) => {
-            variants_of_interest_process(cmd_args).expect(&format!("{module}::VariantsOfInterest"))
-        }
+        Commands::VariantsOfInterest(cmd_args) => variants_of_interest_process(cmd_args)
+            .unwrap_or_else(|_| panic!("{module}::VariantsOfInterest")),
         Commands::PositionsOfInterest(cmd_args) => positions_of_interest_process(cmd_args)
-            .expect(&format!("{module}::PositionsOfInterest")),
+            .unwrap_or_else(|_| panic!("{module}::PositionsOfInterest")),
         Commands::FindChemistry(cmd_args) => {
             find_chemistry_process(cmd_args).unwrap_or_die(&format!("{module}::FindChemistry"))
         }
@@ -48,7 +47,7 @@ fn main() {
         }
         Commands::NTDiffs(cmd_args) => all_sample_nt_diffs_process(cmd_args),
         Commands::Plotter(cmd_args) => {
-            plotter_process(cmd_args).expect(&format!("{module}::Plotter"))
+            plotter_process(cmd_args).unwrap_or_else(|_| panic!("{module}::Plotter"))
         }
         _ => {
             eprintln!("mira-oxide: unrecognized command {:?}", args.command);

--- a/src/processes/find_chemistry.rs
+++ b/src/processes/find_chemistry.rs
@@ -274,7 +274,7 @@ impl fmt::Display for ChemistryOutput {
 /// sequences, returns None
 fn get_average_line_length(fastq: &PathBuf) -> Result<Option<usize>, std::io::Error> {
     let sample_size = 5;
-    let file = File::open(&fastq)?;
+    let file = File::open(fastq)?;
     let buf_reader = BufReader::new(file);
     let fastq_reader = FastQReader::new(buf_reader);
 

--- a/src/processes/plotter.rs
+++ b/src/processes/plotter.rs
@@ -1,15 +1,19 @@
 use clap::Parser;
 use csv::ReaderBuilder;
 use glob::glob;
-use plotly::common::{Mode, Title};
-use plotly::configuration::{ImageButtonFormats, ToImageButtonOptions};
-use plotly::layout::{Axis, GridPattern, LayoutGrid};
-use plotly::{Layout, Plot, Sankey, Scatter};
-use std::collections::HashMap;
-use std::error::Error;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use plotly::{
+    Layout, Plot, Sankey, Scatter,
+    common::{Mode, Title},
+    configuration::{ImageButtonFormats, ToImageButtonOptions},
+    layout::{Axis, GridPattern, LayoutGrid},
+};
+use std::{
+    collections::HashMap,
+    error::Error,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
 
 // Add this function to generate consistent colors for segment names
 fn get_segment_color(segment_name: &str) -> &'static str {

--- a/src/processes/positions_of_interest.rs
+++ b/src/processes/positions_of_interest.rs
@@ -1,5 +1,6 @@
 #![allow(unreachable_patterns)]
 #![allow(dead_code, unused_imports)]
+use crate::utils::alignment::align_sequences;
 use clap::Parser;
 use csv::ReaderBuilder;
 use either::Either;
@@ -10,11 +11,8 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Stdin, Write, stdin, stdout},
     path::{Path, PathBuf},
 };
+use zoe::{alignment::ScalarProfile, data::nucleotides::GetCodons};
 use zoe::{alignment::sw::sw_scalar_alignment, prelude::Nucleotides};
-use zoe::{
-    alignment::{ScalarProfile, pairwise_align_with_cigar},
-    data::nucleotides::GetCodons,
-};
 use zoe::{
     data::{ByteIndexMap, StdGeneticCode, WeightMatrix},
     prelude::Len,
@@ -183,24 +181,6 @@ pub fn lines_to_vec<R: BufRead>(reader: R) -> std::io::Result<Vec<Vec<String>>> 
     }
 
     Ok(columns)
-}
-
-pub fn align_sequences<'a>(query: &'a [u8], reference: &'a [u8]) -> (Vec<u8>, Vec<u8>) {
-    const MAPPING: ByteIndexMap<6> = ByteIndexMap::new(*b"ACGTN*", b'N');
-    const WEIGHTS: WeightMatrix<i8, 6> = WeightMatrix::new(&MAPPING, 1, 0, Some(b'N'));
-    const GAP_OPEN: i8 = -1;
-    const GAP_EXTEND: i8 = 0;
-
-    let profile = ScalarProfile::<6>::new(query, WEIGHTS, GAP_OPEN, GAP_EXTEND)
-        .expect("Alignment profile failed");
-    let alignment = sw_scalar_alignment(reference, &profile);
-
-    pairwise_align_with_cigar(
-        reference,
-        query,
-        &alignment.cigar,
-        alignment.ref_range.start,
-    )
 }
 
 pub fn positions_of_interest_process(args: PositionsArgs) -> Result<(), Box<dyn Error>> {

--- a/src/processes/positions_of_interest.rs
+++ b/src/processes/positions_of_interest.rs
@@ -1,5 +1,5 @@
 #![allow(unreachable_patterns)]
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)]
 use crate::utils::alignment::align_sequences;
 use clap::Parser;
 use csv::ReaderBuilder;
@@ -9,13 +9,11 @@ use std::{
     error::Error,
     fs::{File, OpenOptions},
     io::{BufRead, BufReader, BufWriter, Stdin, Write, stdin, stdout},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-use zoe::{alignment::ScalarProfile, data::nucleotides::GetCodons};
-use zoe::{alignment::sw::sw_scalar_alignment, prelude::Nucleotides};
 use zoe::{
-    data::{ByteIndexMap, StdGeneticCode, WeightMatrix},
-    prelude::Len,
+    data::{StdGeneticCode, nucleotides::GetCodons},
+    prelude::{Len, Nucleotides},
 };
 
 #[derive(Debug, Parser)]
@@ -298,8 +296,8 @@ pub fn positions_of_interest_process(args: PositionsArgs) -> Result<(), Box<dyn 
                         .expect("Invalid UTF-8 sequence")
                         .to_string();
                     entry.aa_position = tail_index + 1;
-                    entry.aa_ref = '~' as char;
-                    entry.aa_mut = '~' as char;
+                    entry.aa_ref = '~';
+                    entry.aa_mut = '~';
 
                     if entry.update_entry_from_alignment(
                         &ref_entry.subtype,

--- a/src/processes/positions_of_interest.rs
+++ b/src/processes/positions_of_interest.rs
@@ -1,5 +1,4 @@
 #![allow(unreachable_patterns)]
-#![allow(dead_code)]
 use crate::utils::alignment::align_sequences;
 use clap::Parser;
 use csv::ReaderBuilder;
@@ -65,16 +64,16 @@ pub struct DaisInput {
     subtype: String,
     ref_strain: String,
     protein: String,
-    nt_hash: String,
-    query_nt_seq: String,
-    query_aa_aln_seq: String,
-    cds_id: String,
-    insertion: String,
-    inert_shift: String,
-    cds_seq: String,
+    _nt_hash: String,
+    _query_nt_seq: String,
+    _query_aa_aln_seq: String,
+    _cds_id: String,
+    _insertion: String,
+    _inert_shift: String,
+    _cds_seq: String,
     cds_aln: String,
-    query_nt_coordinates: String,
-    cds_nt_coordinates: String,
+    _query_nt_coordinates: String,
+    _cds_nt_coordinates: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -82,12 +81,12 @@ pub struct RefInput {
     isolate_id: String,
     isolate_name: String,
     subtype: String,
-    passage_history: String,
-    nt_id: String,
+    _passage_history: String,
+    _nt_id: String,
     ctype: String,
     reference_id: String,
     protein: String,
-    aa_aln: String,
+    _aa_aln: String,
     cds_aln: String,
 }
 

--- a/src/processes/variants_of_interest.rs
+++ b/src/processes/variants_of_interest.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code, unused_imports)]
 use crate::utils::alignment::align_sequences;
 use clap::Parser;
 use csv::ReaderBuilder;
@@ -8,13 +7,11 @@ use std::{
     error::Error,
     fs::{File, OpenOptions},
     io::{BufRead, BufReader, BufWriter, Stdin, Write, stdin, stdout},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-use zoe::{alignment::ScalarProfile, data::nucleotides::GetCodons};
-use zoe::{alignment::sw::sw_scalar_alignment, prelude::Nucleotides};
 use zoe::{
-    data::{ByteIndexMap, StdGeneticCode, WeightMatrix},
-    prelude::Len,
+    data::{StdGeneticCode, nucleotides::GetCodons},
+    prelude::{Len, Nucleotides},
 };
 
 #[derive(Debug, Parser)]
@@ -66,16 +63,16 @@ pub struct DaisInput {
     subtype: String,
     ref_strain: String,
     protein: String,
-    nt_hash: String,
-    query_nt_seq: String,
-    query_aa_aln_seq: String,
-    cds_id: String,
-    insertion: String,
-    inert_shift: String,
-    cds_seq: String,
+    _nt_hash: String,
+    _query_nt_seq: String,
+    _query_aa_aln_seq: String,
+    _cds_id: String,
+    _insertion: String,
+    _inert_shift: String,
+    _cds_seq: String,
     cds_aln: String,
-    query_nt_coordinates: String,
-    cds_nt_coordinates: String,
+    _query_nt_coordinates: String,
+    _cds_nt_coordinates: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -83,12 +80,12 @@ pub struct RefInput {
     isolate_id: String,
     isolate_name: String,
     subtype: String,
-    passage_history: String,
-    nt_id: String,
+    _passage_history: String,
+    _nt_id: String,
     ctype: String,
     reference_id: String,
     protein: String,
-    aa_aln: String,
+    _aa_aln: String,
     cds_aln: String,
 }
 

--- a/src/processes/variants_of_interest.rs
+++ b/src/processes/variants_of_interest.rs
@@ -304,8 +304,8 @@ pub fn variants_of_interest_process(args: VariantsArgs) -> Result<(), Box<dyn Er
                             .expect("Invalid UTF-8 sequence")
                             .to_string();
                         entry.aa_position = tail_index + 1;
-                        entry.aa_ref = '~' as char;
-                        entry.aa_mut = '~' as char;
+                        entry.aa_ref = '~';
+                        entry.aa_mut = '~';
 
                         if entry.update_entry_from_alignment(
                             &ref_entry.subtype,

--- a/src/utils/alignment.rs
+++ b/src/utils/alignment.rs
@@ -1,0 +1,26 @@
+use zoe::{
+    alignment::{ScalarProfile, sw::sw_scalar_alignment},
+    data::{ByteIndexMap, WeightMatrix},
+};
+
+pub fn align_sequences<'a>(query: &'a [u8], reference: &'a [u8]) -> (Vec<u8>, Vec<u8>) {
+    const MAPPING: ByteIndexMap<6> = ByteIndexMap::new(*b"ACGTN*", b'N');
+    const WEIGHTS: WeightMatrix<i8, 6> = WeightMatrix::new(&MAPPING, 1, 0, Some(b'N'));
+    const GAP_OPEN: i8 = -1;
+    const GAP_EXTEND: i8 = 0;
+
+    let profile = ScalarProfile::<6>::new(query, &WEIGHTS, GAP_OPEN, GAP_EXTEND)
+        .expect("Alignment profile failed");
+    let alignment = sw_scalar_alignment(reference, &profile);
+    let alignment = match alignment {
+        zoe::alignment::MaybeAligned::Some(alignment) => alignment,
+        zoe::alignment::MaybeAligned::Overflowed => {
+            unreachable!("Overflow will not occur in scalar alignments")
+        }
+        zoe::alignment::MaybeAligned::Unmapped => {
+            return (Vec::new(), Vec::new());
+        }
+    };
+
+    alignment.get_aligned_seqs(reference, query)
+}

--- a/src/utils/fastq_read.rs
+++ b/src/utils/fastq_read.rs
@@ -1,0 +1,44 @@
+use flate2::read::MultiGzDecoder;
+use std::{fs::File, io::Read, path::Path};
+use zoe::{define_whichever, prelude::FastQReader};
+
+define_whichever! {
+    #[doc="An enum for the different acceptable input types"]
+    pub(crate) enum ReadFileZip {
+        #[doc="A reader for a regular uncompressed file"]
+        File(File),
+        #[doc="A reader for a gzip compressed file"]
+        Zipped(MultiGzDecoder<File>),
+    }
+
+    impl Read for ReadFileZip {}
+}
+
+/// If the filename ends in `gz`, the file is assumed to be zipped.
+///
+/// ## Errors
+///
+/// `path` must exist and contain FASTQ data.
+pub(crate) fn is_gz<P: AsRef<Path>>(path: P) -> bool {
+    path.as_ref().extension().is_some_and(|ext| ext == "gz")
+}
+
+/// Open a single FASTQ file.
+///
+/// If it ends in `gz`, returns a [`FastQReader`] backed by
+/// [`ReadFileZip::Zipped`], otherwise, returns a [`FastQReader`] backed by
+/// [`ReadFileZip::File`].
+#[inline]
+pub(crate) fn open_fastq_file<P: AsRef<Path>>(
+    path: P,
+) -> std::io::Result<FastQReader<ReadFileZip>> {
+    let file = File::open(&path)?;
+
+    if is_gz(&path) {
+        Ok(FastQReader::from_readable(ReadFileZip::Zipped(
+            MultiGzDecoder::new(file),
+        ))?)
+    } else {
+        Ok(FastQReader::from_readable(ReadFileZip::File(file))?)
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod alignment;
+pub mod fastq_read;


### PR DESCRIPTION
- Fixes compressed fastq bug in `find_chemistry` 
- adds `read_fastq` in `src/utils` to flexibly handle compressed `fastq` files 
- moves alignment functionality into `src/utils/alignment` 
- cleans up imports and removes some dead variables and fields