### PR TITLE
Switch to using numeric comparison rather than string comparison for sorting merged_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,32 +3,38 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.3] - 2025-03-31
+## [1.5.4] - 2026-04-13
+- [William Chettleburgh](https://github.com/willchet)
+
+### `Fixed`
+- [PR #84](https://github.com/CDCgov/mira-oxide/pull/84) - Fixed sorting of merged data for RSV
+
+## [1.5.3] - 2026-03-31
 - [Amanda Sullivan](https://github.com/mandysulli)
 
 ### `Fixed`
 - [PR #83](https://github.com/CDCgov/mira-oxide/pull/83) - Added rewrite for adding nextclade information to account for changes in nextclade output with version bump.
 
-## [1.5.2] - 2025-03-27
+## [1.5.2] - 2026-03-27
 - [Amanda Sullivan](https://github.com/mandysulli)
 
 ### `Fixed`
 - [PR #82](https://github.com/CDCgov/mira-oxide/pull/82) - Added rewrite the `irma_summary.json` file into the the `summary-report-update` subprocess.
 
-## [1.5.1] - 2025-03-26
+## [1.5.1] - 2026-03-26
 - [Amanda Sullivan](https://github.com/mandysulli)
 
 ### `Fixed`
 - [PR #81](https://github.com/CDCgov/mira-oxide/pull/81) - fixed bug in summary-reports-update where the di_stat values get dropped and return as null.
 
-## [1.5.0] - 2025-03-24
+## [1.5.0] - 2026-03-24
 - [Amanda Sullivan](https://github.com/mandysulli)
 - [Kristine Lacek](https://github.com/kristinelacek)
 
 ### `Added`
 - [PR #49](https://github.com/CDCgov/mira-oxide/pull/49) - new subprocess call `di-stats` that calculates the DI stats for flu genomes.
 
-## [1.4.4] - 2025-03-09
+## [1.4.4] - 2026-03-09
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -38,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 - [PR #76](https://github.com/CDCgov/mira-oxide/pull/76) - Fixed bug that called premature stop codon when reference was just shorter.
 
-## [1.4.3] - 2025-03-05
+## [1.4.3] - 2026-03-05
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -48,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 - [PR #73](https://github.com/CDCgov/mira-oxide/pull/73) - Update pass fail logic so that it does not Pass HA/NA with "premature stop codon"
 
-## [1.4.2] - 2025-03-04
+## [1.4.2] - 2026-03-04
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -58,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 - [PR #71](https://github.com/CDCgov/mira-oxide/pull/71) - No longer printing undetermined for smaples that didn't run. Now the line is left empty. 
 
-## [1.4.1] - 2025-02-26
+## [1.4.1] - 2026-02-26
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -66,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 - [PR #68](https://github.com/CDCgov/mira-oxide/pull/68) - Remove indel count collumn from statichtml since we no longer make that value
 
-## [1.4.0] - 2025-02-12
+## [1.4.0] - 2026-02-12
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 - [Sam Wiley](https://github.com/samcwiley)
@@ -88,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #65](https://github.com/CDCgov/mira-oxide/pull/65) - minor_variants.csv and minor_variants.parq no longer filtered to frequency of 0.05
 - [PR #65](https://github.com/CDCgov/mira-oxide/pull/65) - the minor_indel_count column has been removed from summary.csv, summary.json and summary.parq - may break schemas
 
-## [1.3.2] - 2025-02-02
+## [1.3.2] - 2026-02-02
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -96,14 +102,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #63](https://github.com/CDCgov/mira-oxide/pull/63) - Fix low median coverage flag call and made BYAM subtype call stricter (need 100% of HA segment now).
 
 
-## [1.3.1] - 2025-01-13
+## [1.3.1] - 2026-01-13
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
 ### `Fixed`
 - [PR #62](https://github.com/CDCgov/mira-oxide/pull/62) - Fix compatibility with MIRA-NF.
 
-## [1.3.0] - 2025-01-13
+## [1.3.0] - 2026-01-13
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 
@@ -111,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #60](https://github.com/CDCgov/mira-oxide/pull/60) - Added divide_nt_into_nextclade_vec and write_out_nextclade_fasta_files funcitons to write out nextclade fastsa files that are divided by subtype( and segment for flu).
 - [PR #60](https://github.com/CDCgov/mira-oxide/pull/60) - Added summary_report_update function to add the nextclade clade results back into the summary.csv and sumary.parq files.
 
-## [1.2.3] - 2025-01-05
+## [1.2.3] - 2026-01-05
 
 - [Amanda Sullivan](https://github.com/mandysulli)
 - [Kristine Lacek](https://github.com/kristinelacek)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mira-oxide"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 description = "A set of rusty tools for use in MIRA"
 

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -430,6 +430,7 @@ pub fn compute_dais_variants(
 }
 
 /// Compute CVV DAIS Variants
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub fn compute_cvv_dais_variants(
     ref_seqs_data: &[DaisSeqData],
     sample_seqs_data: &[DaisSeqData],
@@ -444,33 +445,37 @@ pub fn compute_cvv_dais_variants(
         entry.insertion = compute_aa_variants(&entry.aa_aln, &entry.aa_seq);
     }
 
-    for entry in &mut merged_data {
-        entry.insertions_shift_frame = if entry.insertion.is_empty() {
-            "0".to_string()
-        } else {
-            entry.insertion.split(',').count().to_string()
-        };
-    }
+    let mut merged_data_with_num_variants = merged_data
+        .into_iter()
+        .map(|entry| {
+            let num_variants = if entry.insertion.is_empty() {
+                0
+            } else {
+                entry.insertion.split(',').count()
+            };
+            (entry, num_variants)
+        })
+        .collect::<Vec<_>>();
 
     // Filter and sort the data - keep first
-    merged_data.sort_by(|a, b| {
+    merged_data_with_num_variants.sort_by(|(a, a_num_variants), (b, b_num_variants)| {
         a.protein
             .cmp(&b.protein)
             .then(a.sample_id.cmp(&b.sample_id))
-            .then(a.insertions_shift_frame.cmp(&b.insertions_shift_frame))
+            .then(a_num_variants.cmp(b_num_variants))
     });
 
     let mut unique_data = HashMap::new();
-    for entry in merged_data {
+    for (entry, num_variants) in merged_data_with_num_variants {
         let key = (entry.sample_id.clone(), entry.protein.clone());
-        unique_data.entry(key).or_insert(entry);
+        unique_data.entry(key).or_insert((entry, num_variants));
     }
 
     // Filter dais var data based on virus type
-    let filtered_data: Vec<DaisSeqData> = if virus == "sc2-spike" {
+    let filtered_data: Vec<(DaisSeqData, usize)> = if virus == "sc2-spike" {
         unique_data
             .into_values()
-            .filter(|entry| entry.protein == "S")
+            .filter(|(entry, _num_variants)| entry.protein == "S")
             .collect()
     } else {
         unique_data.into_values().collect()
@@ -479,13 +484,14 @@ pub fn compute_cvv_dais_variants(
     // Convert DaisSeqData to DaisVarsData and collect into a Vec
     let result: Vec<DaisVarsData> = filtered_data
         .into_iter()
-        .map(|entry| DaisVarsData {
+        .map(|(entry, num_variants)| DaisVarsData {
             sample_id: entry.sample_id,
             ctype: entry.ctype,
             aa_reference_id: entry.aa_reference_id,
             positional_reference_id: entry.reference.clone(),
             protein: entry.protein.clone(),
-            aa_variant_count: entry.insertions_shift_frame.parse::<i32>().unwrap_or(0),
+            // TODO: Eventually, we can change this field to be a usize perhaps
+            aa_variant_count: num_variants as i32,
             aa_variants: entry.insertion.clone(),
             runid: runid.to_owned(),
             instrument: instrument.to_owned(),


### PR DESCRIPTION
This is my first PR into mira-oxide, so please let me know if there is a different procedure for opening/merging them.

In preparation for DAIS-ribosome v2, I noticed that in `compute_cvv_dais_variants`, we are hijacking the insertions_shift_frame field of DaisSeqData to temporarily store an integer (the number of variants). We then sort based on this field. However, sorting a `String` holding an integer is different than sorting the integer itself, meaning this could be a bug. When switching to DAIS-ribosome's parser, this also won't be possible anymore because the field will be a `bool` rather than `String`. 

Here, I have made a temporary minimal fix that uses a tuple to store the number of variants as an integer.