### PR TITLE
Update Zoe to the latest version (and use new import paths)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ plotly = "0.13.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10.0"
-zoe = { version = "0.0.25", default-features = false, features = [
+zoe = { version = "0.0.28", default-features = false, features = [
     "multiversion",
 ] }
 

--- a/src/processes/positions_of_interest.rs
+++ b/src/processes/positions_of_interest.rs
@@ -12,7 +12,11 @@ use std::{
 };
 use zoe::{
     alignment::{ScalarProfile, sw::sw_scalar_align},
-    data::{ByteIndexMap, StdGeneticCode, WeightMatrix, nucleotides::GetCodons},
+    data::{
+        WeightMatrix,
+        mappings::{ByteIndexMap, StdGeneticCode},
+        nucleotides::GetCodons,
+    },
     prelude::{Len, Nucleotides},
 };
 

--- a/src/processes/variants_of_interest.rs
+++ b/src/processes/variants_of_interest.rs
@@ -11,7 +11,7 @@ use std::{
     path::PathBuf,
 };
 use zoe::{
-    data::{StdGeneticCode, nucleotides::GetCodons},
+    data::{mappings::StdGeneticCode, nucleotides::GetCodons},
     prelude::{Len, Nucleotides},
 };
 

--- a/src/utils/alignment.rs
+++ b/src/utils/alignment.rs
@@ -1,6 +1,6 @@
 use zoe::{
     alignment::{LocalProfiles, MaybeAligned},
-    data::{ByteIndexMap, WeightMatrix},
+    data::{WeightMatrix, mappings::ByteIndexMap},
     prelude::{ProfileSets, SeqSrc},
 };
 


### PR DESCRIPTION
Eventually, I hope to simplify the module import paths in Zoe so that there are fewer re-exports. This PR updates Zoe and pre-emptively adjusts the paths to prevent future breaking changes.

Given that this is a minor PR, we can also "roll up" other changes with this to avoid needing to rebuild the container multiple times, if that is desired.