### PR TITLE
Remove Optional Sample ID from DaisSeqData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-05-13
+- [William Chettleburgh](https://github.com/willchet)
+
+### `Changed`
+- [PR #88](https://github.com/CDCgov/mira-oxide/pull/88) - Internally, `DaisSeqData`, `DaisVarsData`, and `IRMASummary` now hold a non-optional sample ID
+
 ## [1.5.4] - 2026-04-13
 - [William Chettleburgh](https://github.com/willchet)
 

--- a/src/io/create_passfail_heatmap.rs
+++ b/src/io/create_passfail_heatmap.rs
@@ -69,16 +69,13 @@ fn build_records(
         for reference in heatmap_refs {
             // Try to find a summary for this sample/reference
             if let Some(summary) = summaries.iter().find(|s| {
-                s.sample_id.as_ref() == Some(sample)
+                &s.sample_id == sample
                     && normalize_reference(
                         &s.reference.clone().unwrap_or_else(|| "Unknown".to_string()),
                         virus,
                     ) == *reference
             }) {
-                let sample = summary
-                    .sample_id
-                    .clone()
-                    .unwrap_or_else(|| "Unknown".to_string());
+                let sample = &summary.sample_id;
                 let reference = normalize_reference(
                     &summary
                         .reference
@@ -94,7 +91,7 @@ fn build_records(
                     reason = "No assembly".to_string();
                 }
                 let reason = remove_brace_content(&reason);
-                records.push((sample, reference, reason));
+                records.push((sample.clone(), reference, reason));
             } else {
                 // Not found: add default record
                 records.push((sample.clone(), reference.clone(), "No assembly".to_string()));

--- a/src/io/create_statichtml.rs
+++ b/src/io/create_statichtml.rs
@@ -341,7 +341,7 @@ fn dais_vars_to_plotly_json(vars: &[DaisVarsData]) -> String {
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in vars {
-        columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
+        columns[0].push(row.sample_id.clone());
         columns[1].push(row.positional_reference_id.clone());
         columns[2].push(row.protein.clone());
         columns[3].push(row.aa_variant_count.to_string());

--- a/src/io/create_statichtml.rs
+++ b/src/io/create_statichtml.rs
@@ -266,7 +266,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in summary {
-        columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
+        columns[0].push(row.sample_id.clone());
         columns[1].push(row.total_reads.map_or(String::new(), |v| v.to_string()));
         columns[2].push(row.pass_qc.map_or(String::new(), |v| v.to_string()));
         columns[3].push(row.reads_mapped.map_or(String::new(), |v| v.to_string()));

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -252,7 +252,7 @@ pub struct SeqData {
 #[derive(Deserialize, Debug)]
 pub struct DaisSeqData {
     #[serde(rename = "ID")]
-    pub sample_id: Option<String>,
+    pub sample_id: String,
     #[serde(rename = "C_type")]
     pub ctype: String,
     #[serde(rename = "Ref_ID")]

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -249,7 +249,7 @@ pub struct SeqData {
 
 /////////////// Structs to hold dais-ribosome data ///////////////
 /// Dais Sequence Data
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct DaisSeqData {
     #[serde(rename = "ID")]
     pub sample_id: Option<String>,

--- a/src/io/write_json_files.rs
+++ b/src/io/write_json_files.rs
@@ -67,7 +67,7 @@ pub fn write_irma_summary_to_pass_fail_json_file(
     // Extract unique sample_id and reference values
     let unique_sample_ids: Vec<String> = data
         .iter()
-        .filter_map(|item| item.sample_id.clone())
+        .map(|item| item.sample_id.clone())
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
@@ -82,9 +82,9 @@ pub fn write_irma_summary_to_pass_fail_json_file(
     // Create a mapping of (sample_id, reference) to pass_fail_reason
     let mut pass_fail_map: HashMap<(String, String), Option<String>> = HashMap::new();
     for item in data {
-        if let (Some(sample_id), Some(reference)) = (&item.sample_id, &item.reference) {
+        if let Some(reference) = &item.reference {
             pass_fail_map.insert(
-                (sample_id.clone(), reference.clone()),
+                (item.sample_id.clone(), reference.clone()),
                 item.pass_fail_reason.clone(),
             );
         }

--- a/src/io/write_parquet_files.rs
+++ b/src/io/write_parquet_files.rs
@@ -508,8 +508,7 @@ pub fn write_irma_summary_to_parquet(
         return Err("Input data is empty".into());
     }
 
-    let sample_ids_vec: Vec<Option<String>> =
-        extract_field(irma_summary_data, |item| item.sample_id.clone());
+    let sample_ids_vec = extract_field(irma_summary_data, |item| item.sample_id.clone());
     let total_reads_vec = extract_field(irma_summary_data, |item| item.total_reads);
     let pass_qc_vec = extract_field(irma_summary_data, |item| item.pass_qc);
     let reads_mapped_vec = extract_field(irma_summary_data, |item| item.reads_mapped);

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -412,7 +412,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &coverage_data,
             &format!(
                 "{}/mira_{}_coverage.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -420,7 +420,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &read_data,
             &format!(
                 "{}/mira_{}_reads.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -428,7 +428,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &indel_data,
             &format!(
                 "{}/mira_{}_indels.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -436,7 +436,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &minor_variant_data.all_minor_variants,
             &format!(
                 "{}/mira_{}_minor_variants.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -445,7 +445,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &args.virus,
             &format!(
                 "{}/mira_{}_summary.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -453,7 +453,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &nt_seq_vec,
             &format!(
                 "{}/mira_{}_amended_consensus.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -461,7 +461,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &aa_seq_vec,
             &format!(
                 "{}/mira_{}_amino_acid_consensus.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -469,7 +469,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &run_info,
             &format!(
                 "{}/mira_{}_irma_config.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -477,7 +477,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             samplesheet,
             &format!(
                 "{}/mira_{}_samplesheet.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
             &args.runid,
@@ -492,7 +492,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &all_alleles_data,
             &format!(
                 "{}/mira_{}_all_alleles.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;
@@ -504,33 +504,31 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &coverage_data,
         segments,
         &args.virus,
-        &format!("{}/", &args.output_path.display()),
+        &format!("{}/", args.output_path.display()),
     )?;
 
     let sankey_json_per_sample = reads_to_sankey_json(
         &read_data,
         &args.virus,
-        &format!("{}/", &args.output_path.display()),
+        &format!("{}/", args.output_path.display()),
     );
 
     let cov_heatmap_json = coverage_to_heatmap_json(
         &transformed_cov_data,
         &sample_list,
         &args.virus,
-        &format!("{}/", &args.output_path.display()),
+        &format!("{}/", args.output_path.display()),
     );
 
     let pass_fail_heatmap_json = create_passfail_heatmap(
         &irma_summary,
         &sample_list,
         &args.virus,
-        &format!("{}/", &args.output_path.display()),
+        &format!("{}/", args.output_path.display()),
     );
 
-    let barcode_distribution_json = create_barcode_distribution_figure(
-        &read_data,
-        &format!("{}/", &args.output_path.display()),
-    );
+    let barcode_distribution_json =
+        create_barcode_distribution_figure(&read_data, &format!("{}/", args.output_path.display()));
 
     //////////////////////////////// Create staticHTML ////////////////////////////////
     let _ = generate_html_report(

--- a/src/processes/summary_report_update.rs
+++ b/src/processes/summary_report_update.rs
@@ -288,7 +288,7 @@ pub fn summary_report_update_process(args: &SummaryUpdateArgs) -> Result<(), Box
             &args.virus,
             &format!(
                 "{}/mira_{}_summary.parq",
-                &args.output_path.display(),
+                args.output_path.display(),
                 args.runid
             ),
         )?;

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -392,9 +392,9 @@ pub fn compute_dais_variants(
                 }
 
                 let dais_vars_entry = DaisVarsData {
-                    sample_id: sample_entry.sample_id.clone(),
+                    sample_id: Some(sample_entry.sample_id.clone()),
                     ctype: sample_entry.ctype.clone(),
-                    aa_reference_id: ref_entry.sample_id.clone(),
+                    aa_reference_id: Some(ref_entry.sample_id.clone()),
                     positional_reference_id: sample_entry.reference.clone(),
                     protein: sample_entry.protein.clone(),
                     aa_variant_count: var_aa_count,
@@ -485,7 +485,7 @@ pub fn compute_cvv_dais_variants(
     let result: Vec<DaisVarsData> = filtered_data
         .into_iter()
         .map(|(entry, num_variants)| DaisVarsData {
-            sample_id: entry.sample_id,
+            sample_id: Some(entry.sample_id),
             ctype: entry.ctype,
             aa_reference_id: entry.aa_reference_id,
             positional_reference_id: entry.reference.clone(),
@@ -528,7 +528,7 @@ fn merge_sequences(
                     aligned_cds_sequence: sample_entry.aligned_cds_sequence.clone(),
                     reference_nt_positions: sample_entry.reference_nt_positions.clone(),
                     sample_nt_positions: sample_entry.sample_nt_positions.clone(),
-                    aa_reference_id: ref_entry.sample_id.clone(),
+                    aa_reference_id: Some(ref_entry.sample_id.clone()),
                 };
 
                 merged_data.push(merged_entry);
@@ -1391,54 +1391,44 @@ pub fn create_aa_seq_vec(
 
     if virus == "flu" {
         for entry in aa_data {
-            if let Some(sample_id_str) = entry.sample_id.as_ref() {
-                let parts: Vec<&str> = sample_id_str.rsplitn(2, '_').collect();
-                if parts.len() != 2 {
-                    continue;
-                }
+            let parts: Vec<&str> = entry.sample_id.rsplitn(2, '_').collect();
+            if parts.len() != 2 {
+                continue;
+            }
 
-                let sample_id = parts[1].to_string();
+            let sample_id = parts[1].to_string();
 
-                for sample in irma_summary_vec {
-                    if Some(sample_id.clone()) == sample.sample_id
-                        && Some(entry.ctype.clone()) == sample.reference
-                    {
-                        aa_seq_vec.push(AASequences {
-                            sample_id: sample_id.clone(),
-                            sequence: entry.aa_seq.clone(),
-                            protein: Some(entry.protein.clone()),
-                            reference: sample.reference.clone().unwrap_or_else(String::new),
-                            qc_decision: sample
-                                .pass_fail_reason
-                                .clone()
-                                .unwrap_or_else(String::new),
-                            runid: runid.to_owned(),
-                            instrument: instrument.to_owned(),
-                        });
-                    }
+            for sample in irma_summary_vec {
+                if Some(sample_id.clone()) == sample.sample_id
+                    && Some(entry.ctype.clone()) == sample.reference
+                {
+                    aa_seq_vec.push(AASequences {
+                        sample_id: sample_id.clone(),
+                        sequence: entry.aa_seq.clone(),
+                        protein: Some(entry.protein.clone()),
+                        reference: sample.reference.clone().unwrap_or_else(String::new),
+                        qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
+                        runid: runid.to_owned(),
+                        instrument: instrument.to_owned(),
+                    });
                 }
             }
         }
     } else {
         for entry in aa_data {
-            if let Some(sample_id_str) = entry.sample_id.as_ref() {
-                for sample in irma_summary_vec {
-                    if Some(sample_id_str.clone()) == sample.sample_id
-                        && Some(entry.ctype.clone()) == sample.reference
-                    {
-                        aa_seq_vec.push(AASequences {
-                            sample_id: sample_id_str.clone(),
-                            sequence: entry.aa_seq.clone(),
-                            protein: Some(entry.protein.clone()),
-                            reference: sample.reference.clone().unwrap_or_else(String::new),
-                            qc_decision: sample
-                                .pass_fail_reason
-                                .clone()
-                                .unwrap_or_else(String::new),
-                            runid: runid.to_owned(),
-                            instrument: instrument.to_owned(),
-                        });
-                    }
+            for sample in irma_summary_vec {
+                if Some(entry.sample_id.clone()) == sample.sample_id
+                    && Some(entry.ctype.clone()) == sample.reference
+                {
+                    aa_seq_vec.push(AASequences {
+                        sample_id: entry.sample_id.clone(),
+                        sequence: entry.aa_seq.clone(),
+                        protein: Some(entry.protein.clone()),
+                        reference: sample.reference.clone().unwrap_or_else(String::new),
+                        qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
+                        runid: runid.to_owned(),
+                        instrument: instrument.to_owned(),
+                    });
                 }
             }
         }

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -27,7 +27,7 @@ pub struct ProcessedRecord {
 }
 
 /// Dais Variants Struct
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct DaisVarsData {
     pub sample_id: Option<String>,
     pub ctype: String,

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -77,7 +77,7 @@ pub struct ProcessedCoverage {
 /// IRMA struct
 #[derive(Serialize, Debug, Clone)]
 pub struct IRMASummary {
-    pub sample_id: Option<String>,
+    pub sample_id: String,
     pub total_reads: Option<i32>,
     pub pass_qc: Option<i32>,
     pub reads_mapped: Option<i32>,
@@ -991,7 +991,7 @@ pub fn create_irma_summary_vec(
             if *sample == entry.sample_id {
                 found_match = true;
                 irma_summary.push(IRMASummary {
-                    sample_id: Some(entry.sample_id.clone()),
+                    sample_id: entry.sample_id.clone(),
                     reference: Some(entry.reference.clone()),
                     total_reads: Some(entry.total_reads),
                     pass_qc: Some(entry.pass_qc),
@@ -1013,7 +1013,7 @@ pub fn create_irma_summary_vec(
         // If no match was found, push the default IRMASummary entry that will indicate failed
         if !found_match {
             irma_summary.push(IRMASummary {
-                sample_id: Some(sample.clone()),
+                sample_id: sample.clone(),
                 reference: Some("Undetermined".to_owned()),
                 total_reads: Some(0),
                 pass_qc: Some(0),
@@ -1036,8 +1036,7 @@ pub fn create_irma_summary_vec(
     //Update irma_summary with data from other dataframes
     for sample in &mut irma_summary {
         for entry in calc_cov_vec {
-            if sample.sample_id == Some(entry.sample.clone())
-                && sample.reference == Some(entry.reference.clone())
+            if sample.sample_id == entry.sample && sample.reference == Some(entry.reference.clone())
             {
                 sample.percent_reference_coverage = entry.percent_reference_covered;
                 sample.median_coverage = Some(entry.median_coverage);
@@ -1046,7 +1045,7 @@ pub fn create_irma_summary_vec(
 
         if let Some(result) = pos_calc_cov_vec {
             if let Some(entry) = result.iter().find(|entry| {
-                sample.sample_id == Some(entry.sample.clone())
+                sample.sample_id == entry.sample
                     && sample.reference == Some(entry.reference.clone())
             }) {
                 sample.spike_percent_coverage =
@@ -1059,7 +1058,7 @@ pub fn create_irma_summary_vec(
         }
 
         for entry in &filtered_minor_vars_count {
-            if sample.sample_id == entry.sample_id.clone()
+            if Some(&sample.sample_id) == entry.sample_id.as_ref()
                 && sample.reference == Some(entry.reference.clone())
             {
                 sample.count_minor_snv_at_or_over_5_pct = Some(entry.minor_variant_count);
@@ -1068,7 +1067,7 @@ pub fn create_irma_summary_vec(
 
         if let Some(entry) = subtype_vec
             .iter()
-            .find(|entry| entry.sample_id == sample.sample_id)
+            .find(|entry| entry.sample_id == Some(sample.sample_id.clone()))
         {
             sample.subtype = Some(entry.subtype.clone());
         } else {
@@ -1076,8 +1075,7 @@ pub fn create_irma_summary_vec(
         }
 
         if let Some(entry) = di_stats.iter().find(|entry| {
-            sample.sample_id == Some(entry.sample_id.clone())
-                && sample.reference == Some(entry.segment.clone())
+            sample.sample_id == entry.sample_id && sample.reference.as_ref() == Some(&entry.segment)
         }) {
             sample.di_ratios_5prime_3prime = Some(entry.di_ratios_5prime_3prime.clone());
         } else {
@@ -1109,14 +1107,13 @@ impl IRMASummary {
                         let entry_id = &entry.sample_id;
 
                         if entry_id.len() > 2 {
-                            &entry_id[..entry_id.len() - 2]
-                                == self.sample_id.as_deref().unwrap_or("")
+                            entry_id[..entry_id.len() - 2] == self.sample_id
                         } else {
                             false
                         }
                     } else {
                         // Regular comparison
-                        self.sample_id.as_ref() == Some(&entry.sample_id)
+                        self.sample_id == entry.sample_id
                     };
 
                     sample_match
@@ -1275,8 +1272,7 @@ pub fn create_nt_seq_vec(
                     }
 
                     for record in irma_summary_vec {
-                        if let Some(record_sample_id) = &record.sample_id
-                            && sample_id == *record_sample_id
+                        if sample_id == *record.sample_id
                             && record.reference == Some(sample.original_ref.clone())
                             && assigned_segment == sample.ref_type
                         {
@@ -1300,11 +1296,9 @@ pub fn create_nt_seq_vec(
     } else {
         for entry in seq_data {
             for record in irma_summary_vec {
-                if let Some(record_sample_id) = &record.sample_id
-                    && entry.name == *record_sample_id
-                {
+                if entry.name == record.sample_id {
                     nt_seq_vec.push(NTSequences {
-                        sample_id: record_sample_id.clone(),
+                        sample_id: record.sample_id.clone(),
                         sequence: entry.sequence.clone(),
                         target_ref: None,
                         reference: record.reference.clone().unwrap_or(String::new()),
@@ -1397,9 +1391,7 @@ pub fn create_aa_seq_vec(
             let sample_id = parts[1].to_string();
 
             for sample in irma_summary_vec {
-                if Some(sample_id.clone()) == sample.sample_id
-                    && Some(entry.ctype.clone()) == sample.reference
-                {
+                if sample_id == sample.sample_id && Some(entry.ctype.clone()) == sample.reference {
                     aa_seq_vec.push(AASequences {
                         sample_id: sample_id.clone(),
                         sequence: entry.aa_seq.clone(),
@@ -1415,7 +1407,7 @@ pub fn create_aa_seq_vec(
     } else {
         for entry in aa_data {
             for sample in irma_summary_vec {
-                if Some(entry.sample_id.clone()) == sample.sample_id
+                if entry.sample_id == sample.sample_id
                     && Some(entry.ctype.clone()) == sample.reference
                 {
                     aa_seq_vec.push(AASequences {

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -29,7 +29,7 @@ pub struct ProcessedRecord {
 /// Dais Variants Struct
 #[derive(Serialize, Debug)]
 pub struct DaisVarsData {
-    pub sample_id: Option<String>,
+    pub sample_id: String,
     pub ctype: String,
     pub aa_reference_id: Option<String>,
     pub positional_reference_id: String,
@@ -392,7 +392,7 @@ pub fn compute_dais_variants(
                 }
 
                 let dais_vars_entry = DaisVarsData {
-                    sample_id: Some(sample_entry.sample_id.clone()),
+                    sample_id: sample_entry.sample_id.clone(),
                     ctype: sample_entry.ctype.clone(),
                     aa_reference_id: Some(ref_entry.sample_id.clone()),
                     positional_reference_id: sample_entry.reference.clone(),
@@ -485,7 +485,7 @@ pub fn compute_cvv_dais_variants(
     let result: Vec<DaisVarsData> = filtered_data
         .into_iter()
         .map(|(entry, num_variants)| DaisVarsData {
-            sample_id: Some(entry.sample_id),
+            sample_id: entry.sample_id,
             ctype: entry.ctype,
             aa_reference_id: entry.aa_reference_id,
             positional_reference_id: entry.reference.clone(),
@@ -581,14 +581,14 @@ pub fn extract_subtype_flu(
     // Collect all sample IDs
     let mut all_sample_ids: HashSet<String> = HashSet::new();
     for entry in dais_vars {
-        let hold_sample = entry.sample_id.clone().ok_or("Missing sample_id")?;
+        let hold_sample = entry.sample_id.clone();
         let sample_id = hold_sample[..hold_sample.len() - 2].to_string();
         all_sample_ids.insert(sample_id);
     }
 
     // HA extraction
     for entry in dais_vars {
-        let hold_sample = entry.sample_id.clone().ok_or("Missing sample_id")?;
+        let hold_sample = entry.sample_id.clone();
         let sample_ha = hold_sample[..hold_sample.len() - 2].to_string();
 
         let ha = if entry.protein == "HA" {
@@ -614,7 +614,7 @@ pub fn extract_subtype_flu(
 
     // NA extraction
     for entry in dais_vars {
-        let hold_sample = entry.sample_id.clone().ok_or("Missing sample_id")?;
+        let hold_sample = entry.sample_id.clone();
         let sample_na = hold_sample[..hold_sample.len() - 2].to_string();
 
         let na = if entry.protein == "NA" {
@@ -680,7 +680,7 @@ pub fn extract_subtype_sc2(dais_vars: &[DaisVarsData]) -> Result<Vec<Subtype>, B
 
     for entry in dais_vars {
         subtype_data.push(Subtype {
-            sample_id: entry.sample_id.clone(),
+            sample_id: Some(entry.sample_id.clone()),
             subtype: entry.ctype.clone(),
         });
     }
@@ -693,7 +693,7 @@ pub fn extract_subtype_rsv(dais_vars: &[DaisVarsData]) -> Result<Vec<Subtype>, B
 
     for entry in dais_vars {
         subtype_data.push(Subtype {
-            sample_id: entry.sample_id.clone(),
+            sample_id: Some(entry.sample_id.clone()),
             subtype: entry.ctype.clone(),
         });
     }
@@ -1106,19 +1106,17 @@ impl IRMASummary {
                     // Handle sample_id comparison based on virus type
                     let sample_match = if virus == "flu" {
                         // Take the last two characters off entry.sample_id before comparing
-                        if let Some(entry_id) = &entry.sample_id {
-                            if entry_id.len() > 2 {
-                                &entry_id[..entry_id.len() - 2]
-                                    == self.sample_id.as_deref().unwrap_or("")
-                            } else {
-                                false
-                            }
+                        let entry_id = &entry.sample_id;
+
+                        if entry_id.len() > 2 {
+                            &entry_id[..entry_id.len() - 2]
+                                == self.sample_id.as_deref().unwrap_or("")
                         } else {
                             false
                         }
                     } else {
                         // Regular comparison
-                        self.sample_id == entry.sample_id
+                        self.sample_id.as_ref() == Some(&entry.sample_id)
                     };
 
                     sample_match


### PR DESCRIPTION
To continue preparing mira-oxide for the new DAIS-ribosome v2 release, this PR removes the Option wrapping `sample_id` for `DaisSeqData`, `DaisVarsData`, and `IRMASummary`. It also removes some unneeded derived `Deserialize` implementations.