### PR TITLE
Filter by virus type earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 - [PR #88](https://github.com/CDCgov/mira-oxide/pull/88) - Internally, `DaisSeqData`, `DaisVarsData`, and `IRMASummary` now hold a non-optional sample ID
+- [PR #89](https://github.com/CDCgov/mira-oxide/pull/88) - Internally, filtering for the spike protein in `compute_cvv_dais_variants` happens sooner
 
 ## [1.5.4] - 2026-04-13
 - [William Chettleburgh](https://github.com/willchet)

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -440,6 +440,11 @@ pub fn compute_cvv_dais_variants(
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut merged_data = merge_sequences(ref_seqs_data, sample_seqs_data);
 
+    // Filter dais var data based on virus type
+    if virus == "sc2-spike" {
+        merged_data.retain(|entry| entry.protein == "S");
+    }
+
     // Compute AA Variants
     for entry in &mut merged_data {
         entry.insertion = compute_aa_variants(&entry.aa_aln, &entry.aa_seq);
@@ -471,19 +476,9 @@ pub fn compute_cvv_dais_variants(
         unique_data.entry(key).or_insert((entry, num_variants));
     }
 
-    // Filter dais var data based on virus type
-    let filtered_data: Vec<(DaisSeqData, usize)> = if virus == "sc2-spike" {
-        unique_data
-            .into_values()
-            .filter(|(entry, _num_variants)| entry.protein == "S")
-            .collect()
-    } else {
-        unique_data.into_values().collect()
-    };
-
     // Convert DaisSeqData to DaisVarsData and collect into a Vec
-    let result: Vec<DaisVarsData> = filtered_data
-        .into_iter()
+    let result: Vec<DaisVarsData> = unique_data
+        .into_values()
         .map(|(entry, num_variants)| DaisVarsData {
             sample_id: entry.sample_id,
             ctype: entry.ctype,


### PR DESCRIPTION
This PR is non-urgent and does not impact the business logic, but helps simplify the code. In `compute_cvv_dais_variants`, for the spike protein, I moved the filter to the top of the function rather than the bottom. This shouldn't impact anything since the function is solely modifying each merged entry individually and then sorting them. In other words, `modifying -> sorting -> deduplicating -> filtering` is equivalent to `filtering -> modifying -> sorting -> deduplicating`.

If you notice a reason this is incorrect, feel free to let me know.