### PR TITLE
Code Simplification: One-liner for fetching second element of split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 - [PR #88](https://github.com/CDCgov/mira-oxide/pull/88) - Internally, `DaisSeqData`, `DaisVarsData`, and `IRMASummary` now hold a non-optional sample ID
-- [PR #89](https://github.com/CDCgov/mira-oxide/pull/88) - Internally, filtering for the spike protein in `compute_cvv_dais_variants` happens sooner
+- [PR #89](https://github.com/CDCgov/mira-oxide/pull/89) - Internally, filtering for the spike protein in `compute_cvv_dais_variants` happens sooner
+- [PR #90](https://github.com/CDCgov/mira-oxide/pull/90) - Internally, reduce allocations inside `return_seg_data`
 
 ## [1.5.4] - 2026-04-13
 - [William Chettleburgh](https://github.com/willchet)

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -334,12 +334,7 @@ pub fn return_seg_data(
 
     let mut segset: Vec<String> = Vec::new();
     for segment in &segments {
-        let parts: Vec<&str> = segment.split('_').collect();
-        if parts.len() > 1 {
-            segset.push(parts[1].to_string());
-        } else {
-            segset.push(segment.clone());
-        }
+        segset.push(segment.split('_').nth(1).unwrap_or(segment).to_string());
     }
 
     let segset: Vec<String> = segset


### PR DESCRIPTION
Instead of collecting the results of split, then checking its length, then indexing into it, we can express this using the `nth` method of `Iterator`, as well as `unwrap_or`.

This is not urgent in any way, just an optimization I noticed.