### PR TITLE
Use enum for Virus and Platform types in `prepare_mira_reports`

### DIFF
--- a/src/constants/heatmap_ref.rs
+++ b/src/constants/heatmap_ref.rs
@@ -1,3 +1,5 @@
+use crate::processes::prepare_mira_reports::Virus;
+
 // Refs for Flu heatmaps
 pub const FLU_SEGMENTS: [&str; 8] = ["PB1", "PB2", "PA", "HA", "NP", "NA", "MP", "NS"];
 // Refs for SARS-CoV-2 heatmaps
@@ -6,11 +8,10 @@ pub const SC2_GENOME: &str = "SARS-CoV-2";
 pub const RSV_GENOME: &str = "RSV";
 
 // Function to obtain reference based on virus
-pub fn get_references_for_virus(virus: &str) -> Vec<String> {
-    match virus.to_lowercase().as_str() {
-        "flu" => FLU_SEGMENTS.iter().map(ToString::to_string).collect(),
-        "sc2-wgs" | "sc2-spike" => vec![SC2_GENOME.to_string()],
-        "rsv" => vec![RSV_GENOME.to_string()],
-        _ => vec![],
+pub fn get_references_for_virus(virus: Virus) -> Vec<String> {
+    match virus {
+        Virus::Flu => FLU_SEGMENTS.iter().map(ToString::to_string).collect(),
+        Virus::Sc2Wgs | Virus::Sc2Spike => vec![SC2_GENOME.to_string()],
+        Virus::Rsv => vec![RSV_GENOME.to_string()],
     }
 }

--- a/src/io/coverage_json_per_sample.rs
+++ b/src/io/coverage_json_per_sample.rs
@@ -1,4 +1,4 @@
-use crate::io::data_ingest::CoverageData;
+use crate::{io::data_ingest::CoverageData, processes::prepare_mira_reports::Virus};
 use plotly::{
     Plot, Scatter,
     common::{Fill, Line, Mode, Title},
@@ -19,7 +19,7 @@ pub fn create_sample_coverage_fig(
     data: &[CoverageData],
     segments: &[String],
     cov_linear_y: bool,
-    virus: &str,
+    virus: Virus,
 ) -> Result<Plot, Box<dyn Error>> {
     let mut plot = Plot::new();
 
@@ -182,7 +182,7 @@ pub fn create_sample_coverage_fig(
             let y: Vec<i32> = segment_data.iter().map(|d| d.coverage_depth).collect();
 
             // Determine color by virus
-            let color = if virus == "flu" {
+            let color = if virus == Virus::Flu {
                 flu_pattern_colors
                     .iter()
                     .find(|(pattern, _)| segment.contains(pattern))
@@ -255,7 +255,7 @@ pub fn create_sample_coverage_fig(
 pub fn create_coverage_plot(
     data: &[CoverageData],
     segments: Vec<String>,
-    virus: &str,
+    virus: Virus,
     output_file: &str,
 ) -> Result<Vec<SampleCoverageJson>, Box<dyn Error>> {
     let samples: Vec<String> = data

--- a/src/io/coverage_to_heatmap.rs
+++ b/src/io/coverage_to_heatmap.rs
@@ -1,11 +1,12 @@
 use crate::constants::heatmap_ref::get_references_for_virus;
+use crate::processes::prepare_mira_reports::Virus;
 use crate::utils::data_processing::TransformedData;
 use serde_json::json;
 
-fn normalize_rsv_segments(coverage_data: &[TransformedData], virus: &str) -> Vec<TransformedData> {
+fn normalize_rsv_segments(coverage_data: &[TransformedData], virus: Virus) -> Vec<TransformedData> {
     let mut filtered_data = coverage_data.to_vec();
 
-    if virus.to_lowercase() == "rsv" {
+    if virus == Virus::Rsv {
         for data in &mut filtered_data {
             if data.ref_id.contains("AD") || data.ref_id.contains("BD") {
                 data.ref_id = "RSV".to_string();
@@ -136,7 +137,7 @@ fn build_layout_json(colorscale: &[(f64, &str)]) -> serde_json::Value {
 pub fn coverage_to_heatmap_json(
     coverage_data: &[TransformedData],
     sample_list: &[String],
-    virus: &str,
+    virus: Virus,
     output_file: &str,
 ) -> serde_json::Value {
     println!("Building coverage heatmap as JSON");

--- a/src/io/create_passfail_heatmap.rs
+++ b/src/io/create_passfail_heatmap.rs
@@ -1,4 +1,5 @@
 use crate::constants::heatmap_ref::get_references_for_virus;
+use crate::processes::prepare_mira_reports::Virus;
 use crate::utils::data_processing::IRMASummary;
 use serde_json::json;
 use std::fs::File;
@@ -17,9 +18,9 @@ fn assign_number(reason: &str) -> i32 {
     }
 }
 
-fn normalize_reference(reference: &str, virus: &str) -> String {
+fn normalize_reference(reference: &str, virus: Virus) -> String {
     match virus {
-        "flu" => {
+        Virus::Flu => {
             let parts: Vec<&str> = reference.split('_').collect();
             if parts.len() >= 2 {
                 parts[1].to_string()
@@ -27,7 +28,7 @@ fn normalize_reference(reference: &str, virus: &str) -> String {
                 reference.to_string()
             }
         }
-        "rsv" => reference
+        Virus::Rsv => reference
             .replace("_AD", "")
             .replace("_BD", "")
             .replace("_A", "")
@@ -61,7 +62,7 @@ fn build_records(
     summaries: &[IRMASummary],
     heatmap_refs: &[String],
     sample_list: &[String],
-    virus: &str,
+    virus: Virus,
 ) -> Vec<(String, String, String)> {
     let mut records = Vec::new();
 
@@ -290,7 +291,7 @@ fn plotly_template(colorscale: &Vec<(f64, &str)>) -> serde_json::Value {
 pub fn create_passfail_heatmap(
     summaries: &[IRMASummary],
     sample_list: &[String],
-    virus: &str,
+    virus: Virus,
     output_path: &str,
 ) -> serde_json::Value {
     println!("Building pass_fail_heatmap as JSON");

--- a/src/io/create_statichtml.rs
+++ b/src/io/create_statichtml.rs
@@ -2,6 +2,7 @@
 use super::coverage_json_per_sample::SampleCoverageJson;
 use super::data_ingest::{IndelsData, MinorVariantsData};
 use super::reads_to_sankey_json::SampleSankeyJson;
+use crate::processes::prepare_mira_reports::Virus;
 use crate::processes::summary_report_update::UpdatedIRMASummary;
 use crate::utils::data_processing::{DaisVarsData, IRMASummary};
 use glob::glob;
@@ -210,10 +211,10 @@ pub fn plotly_table_script(div_id: &str, table_json: &str, table_title: &str) ->
 
 // functions to read in table data and render as HTML table
 #[allow(clippy::must_use_candidate)]
-pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> String {
+pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: Virus) -> String {
     // Determine headers dynamically based on virus type
     let headers: Vec<&str> = match virus {
-        "sc2-wgs" => vec![
+        Virus::Sc2Wgs => vec![
             "Sample",
             "Total Reads",
             "Pass QC",
@@ -230,7 +231,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
             "Run ID",
             "Instrument",
         ],
-        "flu" => vec![
+        Virus::Flu => vec![
             "Sample",
             "Total Reads",
             "Pass QC",
@@ -283,7 +284,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
 
         // Virus-specific extra columns
         let mut col_index = 8;
-        if virus == "sc2-wgs" {
+        if virus == Virus::Sc2Wgs {
             columns[col_index].push(
                 row.spike_percent_coverage
                     .map_or(String::new(), |v| format!("{v:.2}")),
@@ -297,7 +298,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
         }
 
         // Correct placement of DI Ratios for flu
-        if virus == "flu" {
+        if virus == Virus::Flu {
             columns[col_index].push(
                 row.di_ratios_5prime_3prime
                     .as_deref()
@@ -355,8 +356,8 @@ fn dais_vars_to_plotly_json(vars: &[DaisVarsData]) -> String {
     .to_string()
 }
 
-fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
-    let headers = if virus == "sc2-spike" {
+fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: Virus) -> String {
+    let headers = if virus == Virus::Sc2Spike {
         [
             "Sample",
             "Reference",
@@ -388,7 +389,7 @@ fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in data {
-        if virus == "sc2-spike" {
+        if virus == Virus::Sc2Spike {
             columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
             columns[1].push(row.reference.clone());
             columns[2].push(
@@ -425,8 +426,8 @@ fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
     .to_string()
 }
 
-fn indels_to_plotly_json(data: &[IndelsData], virus: &str) -> String {
-    let headers = if virus == "sc2-spike" {
+fn indels_to_plotly_json(data: &[IndelsData], virus: Virus) -> String {
+    let headers = if virus == Virus::Sc2Spike {
         [
             "Sample",
             "Reference",
@@ -459,7 +460,7 @@ fn indels_to_plotly_json(data: &[IndelsData], virus: &str) -> String {
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in data {
-        if virus == "sc2-spike" {
+        if virus == Virus::Sc2Spike {
             columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
             columns[1].push(row.reference_name.clone());
             columns[2].push(
@@ -517,7 +518,7 @@ pub fn generate_html_report(
     sankey_json_per_sample: &[SampleSankeyJson],
     runid: &str,
     logo_path: Option<&Path>,
-    virus: &str,
+    virus: Virus,
 ) -> std::io::Result<()> {
     println!("Building static HTML file");
 

--- a/src/io/create_statichtml.rs
+++ b/src/io/create_statichtml.rs
@@ -2,6 +2,7 @@
 use super::coverage_json_per_sample::SampleCoverageJson;
 use super::data_ingest::{IndelsData, MinorVariantsData};
 use super::reads_to_sankey_json::SampleSankeyJson;
+use crate::processes::prepare_mira_reports::Virus;
 use crate::processes::summary_report_update::UpdatedIRMASummary;
 use crate::utils::data_processing::{DaisVarsData, IRMASummary};
 use glob::glob;
@@ -210,10 +211,10 @@ pub fn plotly_table_script(div_id: &str, table_json: &str, table_title: &str) ->
 
 // functions to read in table data and render as HTML table
 #[allow(clippy::must_use_candidate)]
-pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> String {
+pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: Virus) -> String {
     // Determine headers dynamically based on virus type
     let headers: Vec<&str> = match virus {
-        "sc2-wgs" => vec![
+        Virus::Sc2Wgs => vec![
             "Sample",
             "Total Reads",
             "Pass QC",
@@ -230,7 +231,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
             "Run ID",
             "Instrument",
         ],
-        "flu" => vec![
+        Virus::Flu => vec![
             "Sample",
             "Total Reads",
             "Pass QC",
@@ -283,7 +284,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
 
         // Virus-specific extra columns
         let mut col_index = 8;
-        if virus == "sc2-wgs" {
+        if virus == Virus::Sc2Wgs {
             columns[col_index].push(
                 row.spike_percent_coverage
                     .map_or(String::new(), |v| format!("{v:.2}")),
@@ -297,7 +298,7 @@ pub fn irma_summary_to_plotly_json(summary: &[IRMASummary], virus: &str) -> Stri
         }
 
         // Correct placement of DI Ratios for flu
-        if virus == "flu" {
+        if virus == Virus::Flu {
             columns[col_index].push(
                 row.di_ratios_5prime_3prime
                     .as_deref()
@@ -355,8 +356,8 @@ fn dais_vars_to_plotly_json(vars: &[DaisVarsData]) -> String {
     .to_string()
 }
 
-fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
-    let headers = if virus == "sc2-spike" {
+fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: Virus) -> String {
+    let headers = if virus == Virus::Sc2Spike {
         [
             "Sample",
             "Reference",
@@ -388,7 +389,7 @@ fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in data {
-        if virus == "sc2-spike" {
+        if virus == Virus::Sc2Spike {
             columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
             columns[1].push(row.reference.clone());
             columns[2].push(
@@ -425,8 +426,8 @@ fn alleles_to_plotly_json(data: &[MinorVariantsData], virus: &str) -> String {
     .to_string()
 }
 
-fn indels_to_plotly_json(data: &[IndelsData], virus: &str) -> String {
-    let headers = if virus == "sc2-spike" {
+fn indels_to_plotly_json(data: &[IndelsData], virus: Virus) -> String {
+    let headers = if virus == Virus::Sc2Spike {
         [
             "Sample",
             "Reference",
@@ -459,7 +460,7 @@ fn indels_to_plotly_json(data: &[IndelsData], virus: &str) -> String {
     let mut columns: Vec<Vec<String>> = vec![Vec::new(); headers.len()];
 
     for row in data {
-        if virus == "sc2-spike" {
+        if virus == Virus::Sc2Spike {
             columns[0].push(row.sample_id.as_deref().unwrap_or("").to_string());
             columns[1].push(row.reference_name.clone());
             columns[2].push(
@@ -606,7 +607,7 @@ pub fn generate_html_report(
     sankey_json_per_sample: &[SampleSankeyJson],
     runid: &str,
     logo_path: Option<&Path>,
-    virus: &str,
+    virus: Virus,
 ) -> std::io::Result<()> {
     println!("Building static HTML file");
 

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -17,7 +17,7 @@ use crate::processes::prepare_mira_reports::{Platform, Virus};
 /////////////// Structs to hold IRMA data ///////////////
 ///
 ///QC structs
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct QCSettings {
     pub med_cov: u32,
     pub minor_vars: u32,

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -5,11 +5,14 @@ use serde::{self, Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use std::{
     collections::HashMap,
     error::Error,
+    fmt::Display,
     fs::{File, OpenOptions},
     io::{self, BufRead, BufReader, Read, Stdin},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use crate::processes::prepare_mira_reports::Virus;
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
@@ -485,9 +488,9 @@ pub fn coverage_data_collection(
     irma_path: impl AsRef<Path>,
     platform: &str,
     runid: &str,
-    virus: &str,
+    virus: Virus,
 ) -> Result<Vec<CoverageData>, Box<dyn std::error::Error>> {
-    let pattern = if virus.to_lowercase() == "sc2-spike" {
+    let pattern = if virus == Virus::Sc2Spike {
         format!(
             "{}/*/IRMA/*/tables/*coverage.a2m.txt",
             irma_path.as_ref().display()
@@ -514,7 +517,7 @@ pub fn coverage_data_collection(
                     process_txt_with_sample(reader, true, &sample)?;
 
                 // If virus is "sc2-spike", replace position with hmm_position
-                if virus == "sc2-spike" {
+                if virus == Virus::Sc2Spike {
                     for line in &mut records {
                         line.position = line.hmm_position.unwrap_or(0);
                     }
@@ -732,10 +735,10 @@ pub fn all_alleles_data_collection(
 /// Read in IRMA amended consensus fasta files to `SeqData` struct
 pub fn amended_consensus_data_collection(
     irma_path: impl AsRef<Path>,
-    organism: &str,
+    organism: Virus,
 ) -> Result<Vec<SeqData>, Box<dyn std::error::Error>> {
     // Determine the glob pattern based on the organism
-    let pattern = if organism == "flu" || organism == "sc2-spike" {
+    let pattern = if organism == Virus::Flu || organism == Virus::Sc2Spike {
         format!(
             "{}/*/IRMA/*/amended_consensus/*fa",
             irma_path.as_ref().display()
@@ -1020,7 +1023,7 @@ pub fn dais_sequence_data_collection(
 /// Read in dais-ribosome ins file fto `DaisSeqData` struct
 pub fn dais_ref_seq_data_collection(
     dais_path: impl AsRef<Path>,
-    organism: &str,
+    organism: impl Display,
 ) -> Result<Vec<DaisSeqData>, Box<dyn std::error::Error>> {
     // Construct the glob pattern for matching files
     let pattern = format!(

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -12,12 +12,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::processes::prepare_mira_reports::Virus;
+use crate::processes::prepare_mira_reports::{Platform, Virus};
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
 ///QC structs
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct QCSettings {
     pub med_cov: u32,
     pub minor_vars: u32,
@@ -486,7 +486,7 @@ pub fn split_by_comma(input: &str) -> Vec<String> {
 /// Read in the coverage files made by IRMA and save to a vector of `CoverageData`
 pub fn coverage_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
     virus: Virus,
 ) -> Result<Vec<CoverageData>, Box<dyn std::error::Error>> {
@@ -539,7 +539,7 @@ pub fn coverage_data_collection(
 ///  Collect read data created by IRMA and save to vector of `ReadsData`
 pub fn reads_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<ReadsData>, Box<dyn std::error::Error>> {
     let pattern = format!(
@@ -578,7 +578,7 @@ pub fn reads_data_collection(
 /// One vector contains filtered minor variants (frequency >= 0.05), and the other contains all minor variants.
 pub fn minor_variant_data_collection(
     irma_path: &Path,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<MinorVariantDataCollection, Box<dyn std::error::Error>> {
     let pattern = format!(
@@ -633,7 +633,7 @@ pub fn minor_variant_data_collection(
 /// Note that insertions and deletions are being added  to the same Vec<Indelsdata>
 pub fn indels_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<IndelsData>, Box<dyn std::error::Error>> {
     let pattern1 = format!(
@@ -694,7 +694,7 @@ pub fn indels_data_collection(
 /// Collecting allele data created by IRMA and save to a vector of `AllAllelesData`
 pub fn all_alleles_data_collection(
     irma_path: &Path,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<AllAllelesData>, Box<dyn std::error::Error>> {
     let pattern = format!(
@@ -935,7 +935,7 @@ fn days_in_year(year: u64) -> u64 {
 /// Collect read info created by IRMA and save to struct of `RunInfo`
 pub fn run_info_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<RunInfo>, Box<dyn std::error::Error>> {
     let pattern = format!(

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -12,12 +12,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::processes::prepare_mira_reports::Virus;
+use crate::processes::prepare_mira_reports::{Platform, Virus};
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
 ///QC structs
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct QCSettings {
     pub med_cov: u32,
     pub minor_vars: u32,
@@ -489,7 +489,7 @@ pub fn split_by_comma(input: &str) -> Vec<String> {
 /// Read in the coverage files made by IRMA and save to a vector of `CoverageData`
 pub fn coverage_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
     virus: Virus,
 ) -> Result<Vec<CoverageData>, Box<dyn std::error::Error>> {
@@ -536,7 +536,7 @@ pub fn coverage_data_collection(
 ///  Collect read data created by IRMA and save to vector of `ReadsData`
 pub fn reads_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<ReadsData>, Box<dyn std::error::Error>> {
     let pattern = format!("{}/**/READ_COUNTS.txt", irma_path.as_ref().display());
@@ -572,7 +572,7 @@ pub fn reads_data_collection(
 /// One vector contains filtered minor variants (frequency >= 0.05), and the other contains all minor variants.
 pub fn minor_variant_data_collection(
     irma_path: &Path,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<MinorVariantDataCollection, Box<dyn std::error::Error>> {
     let pattern = format!("{}/**/*variants.txt", irma_path.to_string_lossy());
@@ -624,7 +624,7 @@ pub fn minor_variant_data_collection(
 /// Note that insertions and deletions are being added  to the same Vec<Indelsdata>
 pub fn indels_data_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<IndelsData>, Box<dyn std::error::Error>> {
     let pattern1 = format!("{}/**/*insertions.txt", irma_path.as_ref().display());
@@ -679,7 +679,7 @@ pub fn indels_data_collection(
 /// Collecting allele data created by IRMA and save to a vector of `AllAllelesData`
 pub fn all_alleles_data_collection(
     irma_path: &Path,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<AllAllelesData>, Box<dyn std::error::Error>> {
     let pattern = format!("{}/**/*allAlleles.txt", irma_path.to_string_lossy());
@@ -908,7 +908,7 @@ fn days_in_year(year: u64) -> u64 {
 /// Collect read info created by IRMA and save to struct of `RunInfo`
 pub fn run_info_collection(
     irma_path: impl AsRef<Path>,
-    platform: &str,
+    platform: Platform,
     runid: &str,
 ) -> Result<Vec<RunInfo>, Box<dyn std::error::Error>> {
     let pattern = format!("{}/**/run_info.txt", irma_path.as_ref().display());

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -5,11 +5,14 @@ use serde::{self, Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use std::{
     collections::HashMap,
     error::Error,
+    fmt::Display,
     fs::{File, OpenOptions},
     io::{self, BufRead, BufReader, Read, Stdin},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use crate::processes::prepare_mira_reports::Virus;
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
@@ -488,9 +491,9 @@ pub fn coverage_data_collection(
     irma_path: impl AsRef<Path>,
     platform: &str,
     runid: &str,
-    virus: &str,
+    virus: Virus,
 ) -> Result<Vec<CoverageData>, Box<dyn std::error::Error>> {
-    let pattern = if virus.to_lowercase() == "sc2-spike" {
+    let pattern = if virus == Virus::Sc2Spike {
         format!("{}/**/*coverage.a2m.txt", irma_path.as_ref().display())
     } else {
         format!("{}/**/*coverage.txt", irma_path.as_ref().display())
@@ -511,7 +514,7 @@ pub fn coverage_data_collection(
                     process_txt_with_sample(reader, true, &sample)?;
 
                 // If virus is "sc2-spike", replace position with hmm_position
-                if virus == "sc2-spike" {
+                if virus == Virus::Sc2Spike {
                     for line in &mut records {
                         line.position = line.hmm_position.unwrap_or(0);
                     }
@@ -714,10 +717,10 @@ pub fn all_alleles_data_collection(
 /// Read in IRMA amended consensus fasta files to `SeqData` struct
 pub fn amended_consensus_data_collection(
     irma_path: impl AsRef<Path>,
-    organism: &str,
+    organism: Virus,
 ) -> Result<Vec<SeqData>, Box<dyn std::error::Error>> {
     // Determine the glob pattern based on the organism
-    let pattern = if organism == "flu" || organism == "sc2-spike" {
+    let pattern = if organism == Virus::Flu || organism == Virus::Sc2Spike {
         format!("{}/**/*fa", irma_path.as_ref().display())
     } else {
         format!("{}/**/*pad.fa", irma_path.as_ref().display())
@@ -990,7 +993,7 @@ pub fn dais_sequence_data_collection(
 /// Read in dais-ribosome ins file fto `DaisSeqData` struct
 pub fn dais_ref_seq_data_collection(
     dais_path: impl AsRef<Path>,
-    organism: &str,
+    organism: impl Display,
 ) -> Result<Vec<DaisSeqData>, Box<dyn std::error::Error>> {
     // Construct the glob pattern for matching files
     let pattern = format!(

--- a/src/io/reads_to_sankey_json.rs
+++ b/src/io/reads_to_sankey_json.rs
@@ -1,4 +1,4 @@
-use crate::io::data_ingest::ReadsData;
+use crate::{io::data_ingest::ReadsData, processes::prepare_mira_reports::Virus};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 
@@ -19,7 +19,7 @@ fn seg(label: &str) -> std::string::String {
     label.to_string()
 }
 #[allow(clippy::too_many_lines)]
-fn dash_reads_to_sankey(data: &[ReadsData], virus: &str) -> Value {
+fn dash_reads_to_sankey(data: &[ReadsData], virus: Virus) -> Value {
     // Filter out rows where "Stage" is None or "Stage" is 0 or 5
     let filtered_data: Vec<_> = data
         .iter()
@@ -79,7 +79,7 @@ fn dash_reads_to_sankey(data: &[ReadsData], virus: &str) -> Value {
                 // Default: stage 4→N nodes
 
                 // 🔹 If virus == flu, try matching segment prefix
-                if virus == "flu" {
+                if virus == Virus::Flu {
                     let mut applied_flu_color = None;
 
                     // Try each prefix (HA, NA, ...)
@@ -168,7 +168,7 @@ fn dash_reads_to_sankey(data: &[ReadsData], virus: &str) -> Value {
 #[must_use]
 pub fn reads_to_sankey_json(
     data: &[ReadsData],
-    virus: &str,
+    virus: Virus,
     output_file: &str,
 ) -> Vec<SampleSankeyJson> {
     println!("Building read sankey plots as JSON");

--- a/src/io/write_csv_files.rs
+++ b/src/io/write_csv_files.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::{error::Error, path::Path};
 
 use crate::{
-    processes::summary_report_update::UpdatedIRMASummary,
+    processes::{prepare_mira_reports::Virus, summary_report_update::UpdatedIRMASummary},
     utils::data_processing::{AASequences, DaisVarsData, IRMASummary, NTSequences},
 };
 
@@ -61,7 +61,7 @@ pub fn write_out_all_csv_mira_reports(
     aa_seq_vec: &[AASequences],
     run_info: &[RunInfo],
     runid: &str,
-    virus: &str,
+    virus: Virus,
 ) -> Result<(), Box<dyn Error>> {
     // Writing out Coverage data
     let coverage_struct_values = vec![
@@ -127,7 +127,7 @@ pub fn write_out_all_csv_mira_reports(
     )?;
 
     // Writing out minor variants data
-    let minor_variants_columns = if virus == "sc2-spike" {
+    let minor_variants_columns = if virus == Virus::Sc2Spike {
         vec![
             "sample",
             "reference",
@@ -157,7 +157,7 @@ pub fn write_out_all_csv_mira_reports(
         ]
     };
 
-    let minor_vars_struct_values = if virus == "sc2-spike" {
+    let minor_vars_struct_values = if virus == Virus::Sc2Spike {
         vec![
             "Sample",
             "Reference_Name",
@@ -246,7 +246,7 @@ pub fn write_out_all_csv_mira_reports(
     )?;
 
     // write out the mira_{runid}_summary.csv
-    let summary_struct_values: Vec<&str> = if virus == "sc2-wgs" {
+    let summary_struct_values: Vec<&str> = if virus == Virus::Sc2Wgs {
         vec![
             "sample_id",
             "total_reads",
@@ -264,7 +264,7 @@ pub fn write_out_all_csv_mira_reports(
             "runid",
             "instrument",
         ]
-    } else if virus == "flu" {
+    } else if virus == Virus::Flu {
         vec![
             "sample_id",
             "total_reads",
@@ -299,7 +299,7 @@ pub fn write_out_all_csv_mira_reports(
         ]
     };
 
-    let summary_columns: Vec<&str> = if virus == "sc2-wgs" {
+    let summary_columns: Vec<&str> = if virus == Virus::Sc2Wgs {
         vec![
             "sample_id",
             "total_reads",
@@ -317,7 +317,7 @@ pub fn write_out_all_csv_mira_reports(
             "runid",
             "instrument",
         ]
-    } else if virus == "flu" {
+    } else if virus == Virus::Flu {
         vec![
             "sample_id",
             "total_reads",

--- a/src/io/write_json_files.rs
+++ b/src/io/write_json_files.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::{
-    processes::summary_report_update::UpdatedIRMASummary,
+    processes::{prepare_mira_reports::Virus, summary_report_update::UpdatedIRMASummary},
     utils::data_processing::{
         DaisVarsData, IRMASummary, NTSequences, ProcessedRecord, filter_struct_by_ids,
     },
@@ -200,7 +200,7 @@ pub fn write_out_all_json_files(
     neg_control_list: &[String],
     irma_summary: &[IRMASummary],
     nt_seq_vec: &[NTSequences],
-    virus: &str,
+    virus: Virus,
 ) -> Result<(), Box<dyn Error>> {
     // Writing out Coverage data
     let coverage_struct_values = vec![
@@ -269,7 +269,7 @@ pub fn write_out_all_json_files(
     )?;
 
     // Writing out minor variants
-    let minor_vars_columns = if virus == "sc2-spike" {
+    let minor_vars_columns = if virus == Virus::Sc2Spike {
         vec![
             "sample",
             "reference",
@@ -298,7 +298,7 @@ pub fn write_out_all_json_files(
             "instrument",
         ]
     };
-    let minor_vars_struct_values = if virus == "sc2-spike" {
+    let minor_vars_struct_values = if virus == Virus::Sc2Spike {
         vec![
             "Sample",
             "Reference_Name",
@@ -390,7 +390,7 @@ pub fn write_out_all_json_files(
     )?;
 
     // write out the summary.json
-    let summary_struct_values: Vec<&str> = if virus == "sc2-wgs" {
+    let summary_struct_values: Vec<&str> = if virus == Virus::Sc2Wgs {
         vec![
             "sample_id",
             "total_reads",
@@ -408,7 +408,7 @@ pub fn write_out_all_json_files(
             "runid",
             "instrument",
         ]
-    } else if virus == "flu" {
+    } else if virus == Virus::Flu {
         vec![
             "sample_id",
             "total_reads",
@@ -443,7 +443,7 @@ pub fn write_out_all_json_files(
         ]
     };
 
-    let summary_columns: Vec<&str> = if virus == "sc2-wgs" {
+    let summary_columns: Vec<&str> = if virus == Virus::Sc2Wgs {
         vec![
             "sample_id",
             "total_reads",
@@ -461,7 +461,7 @@ pub fn write_out_all_json_files(
             "runid",
             "instrument",
         ]
-    } else if virus == "flu" {
+    } else if virus == Virus::Flu {
         vec![
             "sample_id",
             "total_reads",
@@ -509,7 +509,7 @@ pub fn write_out_all_json_files(
     )?;
 
     // write out the nt_sequences.json
-    let nt_seq_columns: Vec<&str> = if virus == "flu" {
+    let nt_seq_columns: Vec<&str> = if virus == Virus::Flu {
         vec!["sample_id", "sequence", "target_ref", "reference"]
     } else {
         vec!["sample_id", "sequence", "reference"]

--- a/src/io/write_parquet_files.rs
+++ b/src/io/write_parquet_files.rs
@@ -1,5 +1,5 @@
 use crate::io::data_ingest::{AllAllelesData, ReadsData};
-use crate::processes::prepare_mira_reports::Samplesheet;
+use crate::processes::prepare_mira_reports::{Samplesheet, Virus};
 use crate::processes::summary_report_update::UpdatedIRMASummary;
 use crate::utils::data_processing::{AASequences, IRMASummary, NTSequences, extract_field};
 use arrow::array::Float64Array;
@@ -501,7 +501,7 @@ pub fn write_minor_vars_to_parquet(
 #[allow(clippy::too_many_lines)]
 pub fn write_irma_summary_to_parquet(
     irma_summary_data: &[IRMASummary],
-    virus: &str,
+    virus: Virus,
     output_file: &str,
 ) -> Result<(), Box<dyn Error>> {
     if irma_summary_data.is_empty() {
@@ -582,7 +582,7 @@ pub fn write_irma_summary_to_parquet(
     ];
 
     // Existing SC2-specific fields
-    if virus == "sc2-wgs" {
+    if virus == Virus::Sc2Wgs {
         fields.push(Field::new(
             "spike_percent_coverage",
             DataType::Float64,
@@ -595,7 +595,7 @@ pub fn write_irma_summary_to_parquet(
     }
 
     // Flu-specific field - inserted before pass_fail_reason
-    if virus == "flu" {
+    if virus == Virus::Flu {
         let insert_idx = fields
             .iter()
             .position(|f| f.name() == "pass_fail_reason")

--- a/src/io/write_parquet_files.rs
+++ b/src/io/write_parquet_files.rs
@@ -1,5 +1,5 @@
 use crate::io::data_ingest::{AllAllelesData, ReadsData};
-use crate::processes::prepare_mira_reports::{Samplesheet, Virus};
+use crate::processes::prepare_mira_reports::{Platform, Samplesheet, Virus};
 use crate::processes::summary_report_update::UpdatedIRMASummary;
 use crate::utils::data_processing::{AASequences, IRMASummary, NTSequences, extract_field};
 use arrow::array::Float64Array;
@@ -796,7 +796,7 @@ pub fn write_samplesheet_to_parquet(
     samplesheet: Samplesheet,
     output_file: &str,
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<(), Box<dyn Error>> {
     match samplesheet {
         Samplesheet::Illumina(data) => {

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -72,10 +72,9 @@ pub struct ReportsArgs {
     /// The file path to the qc yaml
     qc_yaml: PathBuf,
 
-    #[arg(short = 'p', long)]
+    #[arg(short = 'p', long, ignore_case = true)]
     /// The platform used to generate the data.
-    /// Options: illumina or ont
-    platform: String,
+    platform: Platform,
 
     #[arg(short = 'v', long, ignore_case = true)]
     /// The virus the the data was generated from.
@@ -96,6 +95,37 @@ pub struct ReportsArgs {
     #[arg(short = 'c', long, default_value = "default-config")]
     /// (Optional) The name of the IRMA configuration that was used for running IRMA.
     irma_config: String,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Platform {
+    Illumina,
+    Ont,
+}
+
+impl Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Platform::Illumina => write!(f, "illumina"),
+            Platform::Ont => write!(f, "ont"),
+        }
+    }
+}
+
+// Allows case insensitivity for trim ends
+impl ValueEnum for Platform {
+    #[inline]
+    fn value_variants<'a>() -> &'a [Platform] {
+        &[Platform::Illumina, Platform::Ont]
+    }
+
+    #[inline]
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Platform::Illumina => Some(PossibleValue::new("illumina")),
+            Platform::Ont => Some(PossibleValue::new("ont")),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -180,12 +210,15 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     /////////////// Read in and process data from IRMA and Dais ///////////////
     // Read in samplesheet
     let samplesheet_path = create_reader(&args.samplesheet)?;
-    let samplesheet = if &args.platform == "illumina" {
-        let illumina_samplesheet: Vec<SamplesheetI> = read_csv(samplesheet_path, true)?;
-        Samplesheet::Illumina(illumina_samplesheet)
-    } else {
-        let ont_samplesheet: Vec<SamplesheetO> = read_csv(samplesheet_path, true)?;
-        Samplesheet::ONT(ont_samplesheet)
+    let samplesheet = match args.platform {
+        Platform::Illumina => {
+            let illumina_samplesheet: Vec<SamplesheetI> = read_csv(samplesheet_path, true)?;
+            Samplesheet::Illumina(illumina_samplesheet)
+        }
+        Platform::Ont => {
+            let ont_samplesheet: Vec<SamplesheetO> = read_csv(samplesheet_path, true)?;
+            Samplesheet::ONT(ont_samplesheet)
+        }
     };
 
     // Get sample ids from the samplesheet
@@ -206,13 +239,13 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
 
     // Read in IRMA data
     let coverage_data =
-        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, args.virus)?;
-    let read_data = reads_data_collection(&args.irma_path, &args.platform, &args.runid)?;
+        coverage_data_collection(&args.irma_path, args.platform, &args.runid, args.virus)?;
+    let read_data = reads_data_collection(&args.irma_path, args.platform, &args.runid)?;
     let vtype_data = create_vtype_data(&read_data);
     let minor_variant_data =
-        minor_variant_data_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let indel_data = indels_data_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let run_info = run_info_collection(&args.irma_path, &args.platform, &args.runid)?;
+        minor_variant_data_collection(&args.irma_path, args.platform, &args.runid)?;
+    let indel_data = indels_data_collection(&args.irma_path, args.platform, &args.runid)?;
+    let run_info = run_info_collection(&args.irma_path, args.platform, &args.runid)?;
     let seq_data = amended_consensus_data_collection(&args.irma_path, args.virus)?;
     let ref_lengths = match get_reference_lens(&args.irma_path) {
         Ok(data) => data,
@@ -247,7 +280,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
     if args.virus == Virus::Flu {
         dais_vars_data =
-            compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, &args.platform)?;
+            compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, args.platform)?;
     } else if args.virus == Virus::Sc2Wgs
         || args.virus == Virus::Sc2Spike
         || args.virus == Virus::Rsv
@@ -256,7 +289,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &dais_ref_data,
             &dais_seq_data,
             &args.runid,
-            &args.platform,
+            args.platform,
             args.virus,
         )?;
     }
@@ -288,7 +321,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     //Gather Anlysis Metadata for irma_summary
     let analysis_metadata = collect_analysis_metadata(
         &args.workdir_path,
-        &args.platform,
+        args.platform,
         args.virus,
         &args.irma_config,
         &args.runid,
@@ -306,40 +339,21 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &di_stats_data,
     )?;
 
-    let mut qc_values = QCSettings {
-        med_cov: 0,
-        minor_vars: 0,
-        stop_codon_restricted_proteins: String::new(),
-        perc_ref_covered: 0,
-        negative_control_perc: 0,
-        negative_control_perc_exception: 0,
-        positive_control_minimum: 0,
-        padded_consensus: false,
-        med_spike_cov: None,
-        perc_ref_spike_covered: None,
-    };
     // Set qc values based on given virus and platform
-    if args.virus == Virus::Flu {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_flu;
-        } else {
-            qc_values = qc_config.ont_flu;
+
+    let qc_values = match (args.virus, args.platform) {
+        (Virus::Flu, Platform::Illumina) => qc_config.illumina_flu,
+        (Virus::Flu, Platform::Ont) => qc_config.ont_flu,
+        (Virus::Sc2Wgs, Platform::Illumina) => qc_config.illumina_sc2,
+        (Virus::Sc2Wgs, Platform::Ont) => qc_config.ont_sc2,
+        (Virus::Sc2Spike, Platform::Illumina) => {
+            // This case is not supported, TODO ensure this
+            QCSettings::default()
         }
-    } else if args.virus == Virus::Sc2Wgs {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_sc2;
-        } else {
-            qc_values = qc_config.ont_sc2;
-        }
-    } else if args.virus == Virus::Sc2Spike {
-        qc_values = qc_config.ont_sc2_spike;
-    } else if args.virus == Virus::Rsv {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_rsv;
-        } else {
-            qc_values = qc_config.ont_rsv;
-        }
-    }
+        (Virus::Sc2Spike, Platform::Ont) => qc_config.ont_sc2_spike,
+        (Virus::Rsv, Platform::Illumina) => qc_config.illumina_rsv,
+        (Virus::Rsv, Platform::Ont) => qc_config.ont_rsv,
+    };
 
     // Get proteins that can not have premature stop codons
     let no_premature_stop_codon_proteins =
@@ -359,7 +373,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &irma_summary,
         args.virus,
         &args.runid,
-        &args.platform,
+        args.platform,
     )?;
 
     let aa_seq_vec = create_aa_seq_vec(
@@ -367,19 +381,19 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &irma_summary,
         args.virus,
         &args.runid,
-        &args.platform,
+        args.platform,
     )?;
 
     // Sort into passing and failing\
     let processed_aa_seq = divide_aa_into_pass_fail_vec(
         &aa_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
     let processed_nt_seq = divide_nt_into_pass_fail_vec(
         &nt_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
@@ -387,7 +401,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // Create nextclade sequence vectors for fasta files if flag given
     let nextclade_nt_seq = divide_nt_into_nextclade_vec(
         &nt_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
@@ -519,12 +533,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
                 args.runid
             ),
             &args.runid,
-            &args.platform,
+            args.platform,
         )?;
 
         // Only reading in allAlleles.txt if parquet files are being made
         let all_alleles_data =
-            all_alleles_data_collection(&args.irma_path, &args.platform, &args.runid)?;
+            all_alleles_data_collection(&args.irma_path, args.platform, &args.runid)?;
 
         write_alleles_to_parquet(
             &all_alleles_data,

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -37,11 +37,13 @@ use crate::{
     },
     utils::data_processing::extract_subtype_rsv,
 };
-use clap::Parser;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
 use csv::ReaderBuilder;
 use either::Either;
 use serde::{self, Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::json;
+use std::fmt::Display;
 use std::fs;
 use std::sync::Arc;
 use std::{
@@ -75,10 +77,10 @@ pub struct ReportsArgs {
     /// Options: illumina or ont
     platform: String,
 
-    #[arg(short = 'v', long)]
+    #[arg(short = 'v', long, ignore_case = true)]
     /// The virus the the data was generated from.
     /// Options: flu, sc2-wgs, sc2-spike or rsv
-    virus: String,
+    virus: Virus,
 
     #[arg(short = 'r', long)]
     /// The run id. Used to create custom file names associated with `run_id`.
@@ -95,6 +97,43 @@ pub struct ReportsArgs {
     #[arg(short = 'c', long, default_value = "default-config")]
     /// (Optional) The name of the IRMA configuration that was used for running IRMA.
     irma_config: String,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Virus {
+    Flu,
+    Sc2Wgs,
+    Sc2Spike,
+    Rsv,
+}
+
+impl Display for Virus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Virus::Flu => write!(f, "flu"),
+            Virus::Sc2Wgs => write!(f, "sc2-wgs"),
+            Virus::Sc2Spike => write!(f, "sc2-spike"),
+            Virus::Rsv => write!(f, "rsv"),
+        }
+    }
+}
+
+// Allows case insensitivity for trim ends
+impl ValueEnum for Virus {
+    #[inline]
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Flu, Self::Sc2Wgs, Self::Sc2Spike, Self::Rsv]
+    }
+
+    #[inline]
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Virus::Flu => Some(PossibleValue::new("flu")),
+            Virus::Sc2Wgs => Some(PossibleValue::new("sc2-wgs")),
+            Virus::Sc2Spike => Some(PossibleValue::new("sc2-spike")),
+            Virus::Rsv => Some(PossibleValue::new("rsv")),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -168,14 +207,14 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
 
     // Read in IRMA data
     let coverage_data =
-        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, &args.virus)?;
+        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, args.virus)?;
     let read_data = reads_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let vtype_data = create_vtype_data(&read_data);
     let minor_variant_data =
         minor_variant_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let indel_data = indels_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let run_info = run_info_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let seq_data = amended_consensus_data_collection(&args.irma_path, &args.virus)?;
+    let seq_data = amended_consensus_data_collection(&args.irma_path, args.virus)?;
     let ref_lengths = match get_reference_lens(&args.irma_path) {
         Ok(data) => data,
         Err(e) => {
@@ -192,9 +231,9 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // In MIRA-NF the DAIS outputs are fed right to the working directory to be used in this step
     let dais_seq_data = dais_sequence_data_collection("./")?;
     let mut dais_ref_data: Vec<DaisSeqData> = Vec::new();
-    if args.virus.to_lowercase() == "flu" || args.virus.to_lowercase() == "rsv" {
-        dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, &args.virus)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" || args.virus.to_lowercase() == "sc2-spike" {
+    if args.virus == Virus::Flu || args.virus == Virus::Rsv {
+        dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, args.virus)?;
+    } else if args.virus == Virus::Sc2Wgs || args.virus == Virus::Sc2Spike {
         dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, "sc2")?;
     }
 
@@ -207,19 +246,19 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     //////////////////////////////// Processing ingested IRMA and Dais data ////////////////////////////////
     // Calculate AA variants for aavars.csv and dais_vars.json
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         dais_vars_data =
             compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, &args.platform)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs"
-        || args.virus.to_lowercase() == "sc2-spike"
-        || args.virus.to_lowercase() == "rsv"
+    } else if args.virus == Virus::Sc2Wgs
+        || args.virus == Virus::Sc2Spike
+        || args.virus == Virus::Rsv
     {
         dais_vars_data = compute_cvv_dais_variants(
             &dais_ref_data,
             &dais_seq_data,
             &args.runid,
             &args.platform,
-            &args.virus,
+            args.virus,
         )?;
     }
 
@@ -228,22 +267,22 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let mut calculated_cov_vec: Vec<ProcessedCoverage> = Vec::new();
     let mut calculated_position_cov_vec: Vec<ProcessedCoverage> = Vec::new();
 
-    if args.virus.to_lowercase() == "flu" || args.virus.to_lowercase() == "rsv" {
+    if args.virus == Virus::Flu || args.virus == Virus::Rsv {
         calculated_cov_vec = process_wgs_coverage_data(&coverage_data, &ref_lengths)?;
-    } else if args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Spike {
         calculated_cov_vec = process_position_coverage_data(&coverage_data, 21563, 25384)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" {
+    } else if args.virus == Virus::Sc2Wgs {
         calculated_cov_vec = process_wgs_coverage_data(&coverage_data, &ref_lengths)?;
         calculated_position_cov_vec = process_position_coverage_data(&coverage_data, 21563, 25384)?;
     }
 
     //Gather subtype information
     let mut subtype_data: Vec<Subtype> = Vec::new();
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         subtype_data = extract_subtype_flu(&dais_vars_data, &calculated_cov_vec)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" || args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Wgs || args.virus == Virus::Sc2Spike {
         subtype_data = extract_subtype_sc2(&dais_vars_data)?;
-    } else if args.virus.to_lowercase() == "rsv" {
+    } else if args.virus == Virus::Rsv {
         subtype_data = extract_subtype_rsv(&dais_vars_data)?;
     }
 
@@ -251,7 +290,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let analysis_metadata = collect_analysis_metadata(
         &args.workdir_path,
         &args.platform,
-        &args.virus,
+        args.virus,
         &args.irma_config,
         &args.runid,
     )?;
@@ -281,21 +320,21 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         perc_ref_spike_covered: None,
     };
     // Set qc values based on given virus and platform
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_flu;
         } else {
             qc_values = qc_config.ont_flu;
         }
-    } else if args.virus.to_lowercase() == "sc2-wgs" {
+    } else if args.virus == Virus::Sc2Wgs {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_sc2;
         } else {
             qc_values = qc_config.ont_sc2;
         }
-    } else if args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Spike {
         qc_values = qc_config.ont_sc2_spike;
-    } else if args.virus.to_lowercase() == "rsv" {
+    } else if args.virus == Virus::Rsv {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_rsv;
         } else {
@@ -310,7 +349,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // Add pass fail information to irma summary
     for sample in &mut irma_summary {
         if sample.pass_fail_reason.is_none() {
-            sample.add_pass_fail_qc(&dais_vars_data, &args.virus, &qc_values)?;
+            sample.add_pass_fail_qc(&dais_vars_data, args.virus, &qc_values)?;
         }
     }
 
@@ -319,7 +358,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &seq_data,
         &vtype_data,
         &irma_summary,
-        &args.virus,
+        args.virus,
         &args.runid,
         &args.platform,
     )?;
@@ -327,7 +366,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let aa_seq_vec = create_aa_seq_vec(
         &dais_seq_data,
         &irma_summary,
-        &args.virus,
+        args.virus,
         &args.runid,
         &args.platform,
     )?;
@@ -336,13 +375,13 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let processed_aa_seq = divide_aa_into_pass_fail_vec(
         &aa_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
     let processed_nt_seq = divide_nt_into_pass_fail_vec(
         &nt_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
 
@@ -350,12 +389,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let nextclade_nt_seq = divide_nt_into_nextclade_vec(
         &nt_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
 
     // Processing data for Dashboard Figures
-    let transformed_cov_data = transform_coverage_to_heatmap(&coverage_data, &args.virus);
+    let transformed_cov_data = transform_coverage_to_heatmap(&coverage_data, args.virus);
 
     //////////////////////////////// Write all files ////////////////////////////////
     println!("Writing Output Files...");
@@ -386,7 +425,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &aa_seq_vec,
         &run_info,
         &args.runid,
-        &args.virus,
+        args.virus,
     )?;
 
     println!("Writing JSON files");
@@ -401,7 +440,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &neg_control_list,
         &irma_summary,
         &nt_seq_vec,
-        &args.virus,
+        args.virus,
     )?;
 
     // Write fields to parq if flag given
@@ -442,7 +481,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         )?;
         write_irma_summary_to_parquet(
             &irma_summary,
-            &args.virus,
+            args.virus,
             &format!(
                 "{}/mira_{}_summary.parq",
                 args.output_path.display(),
@@ -503,27 +542,27 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let coverage_json_per_sample = create_coverage_plot(
         &coverage_data,
         segments,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     )?;
 
     let sankey_json_per_sample = reads_to_sankey_json(
         &read_data,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
     let cov_heatmap_json = coverage_to_heatmap_json(
         &transformed_cov_data,
         &sample_list,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
     let pass_fail_heatmap_json = create_passfail_heatmap(
         &irma_summary,
         &sample_list,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
@@ -544,7 +583,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &sankey_json_per_sample,
         &args.runid,
         Some(&args.workdir_path),
-        &args.virus,
+        args.virus,
     );
 
     Ok(())

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -79,7 +79,6 @@ pub struct ReportsArgs {
 
     #[arg(short = 'v', long, ignore_case = true)]
     /// The virus the the data was generated from.
-    /// Options: flu, sc2-wgs, sc2-spike or rsv
     virus: Virus,
 
     #[arg(short = 'r', long)]

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -347,8 +347,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         (Virus::Sc2Wgs, Platform::Illumina) => qc_config.illumina_sc2,
         (Virus::Sc2Wgs, Platform::Ont) => qc_config.ont_sc2,
         (Virus::Sc2Spike, Platform::Illumina) => {
-            // This case is not supported, TODO ensure this
-            QCSettings::default()
+            return Err(format!(
+                "Unhandled case for platform '{platform}' and virus '{virus}'",
+                platform = args.platform,
+                virus = args.virus
+            )
+            .into());
         }
         (Virus::Sc2Spike, Platform::Ont) => qc_config.ont_sc2_spike,
         (Virus::Rsv, Platform::Illumina) => qc_config.illumina_rsv,

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -72,10 +72,9 @@ pub struct ReportsArgs {
     /// The file path to the qc yaml
     qc_yaml: PathBuf,
 
-    #[arg(short = 'p', long)]
+    #[arg(short = 'p', long, ignore_case = true)]
     /// The platform used to generate the data.
-    /// Options: illumina or ont
-    platform: String,
+    platform: Platform,
 
     #[arg(short = 'v', long, ignore_case = true)]
     /// The virus the the data was generated from.
@@ -100,6 +99,37 @@ pub struct ReportsArgs {
     #[arg(short = 't', long, default_value = "")]
     /// (Optional) if a custom qc template is used for QC.
     qc_template: String,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Platform {
+    Illumina,
+    Ont,
+}
+
+impl Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Platform::Illumina => write!(f, "illumina"),
+            Platform::Ont => write!(f, "ont"),
+        }
+    }
+}
+
+// Allows case insensitivity for trim ends
+impl ValueEnum for Platform {
+    #[inline]
+    fn value_variants<'a>() -> &'a [Platform] {
+        &[Platform::Illumina, Platform::Ont]
+    }
+
+    #[inline]
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Platform::Illumina => Some(PossibleValue::new("illumina")),
+            Platform::Ont => Some(PossibleValue::new("ont")),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -184,12 +214,15 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     /////////////// Read in and process data from IRMA and Dais ///////////////
     // Read in samplesheet
     let samplesheet_path = create_reader(&args.samplesheet)?;
-    let samplesheet = if &args.platform == "illumina" {
-        let illumina_samplesheet: Vec<SamplesheetI> = read_csv(samplesheet_path, true)?;
-        Samplesheet::Illumina(illumina_samplesheet)
-    } else {
-        let ont_samplesheet: Vec<SamplesheetO> = read_csv(samplesheet_path, true)?;
-        Samplesheet::ONT(ont_samplesheet)
+    let samplesheet = match args.platform {
+        Platform::Illumina => {
+            let illumina_samplesheet: Vec<SamplesheetI> = read_csv(samplesheet_path, true)?;
+            Samplesheet::Illumina(illumina_samplesheet)
+        }
+        Platform::Ont => {
+            let ont_samplesheet: Vec<SamplesheetO> = read_csv(samplesheet_path, true)?;
+            Samplesheet::ONT(ont_samplesheet)
+        }
     };
 
     // Get sample ids from the samplesheet
@@ -210,13 +243,13 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
 
     // Read in IRMA data
     let coverage_data =
-        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, args.virus)?;
-    let read_data = reads_data_collection(&args.irma_path, &args.platform, &args.runid)?;
+        coverage_data_collection(&args.irma_path, args.platform, &args.runid, args.virus)?;
+    let read_data = reads_data_collection(&args.irma_path, args.platform, &args.runid)?;
     let vtype_data = create_vtype_data(&read_data);
     let minor_variant_data =
-        minor_variant_data_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let indel_data = indels_data_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let run_info = run_info_collection(&args.irma_path, &args.platform, &args.runid)?;
+        minor_variant_data_collection(&args.irma_path, args.platform, &args.runid)?;
+    let indel_data = indels_data_collection(&args.irma_path, args.platform, &args.runid)?;
+    let run_info = run_info_collection(&args.irma_path, args.platform, &args.runid)?;
     let seq_data = amended_consensus_data_collection(&args.irma_path, args.virus)?;
     let ref_lengths = match get_reference_lens(&args.irma_path) {
         Ok(data) => data,
@@ -251,7 +284,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
     if args.virus == Virus::Flu {
         dais_vars_data =
-            compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, &args.platform)?;
+            compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, args.platform)?;
     } else if args.virus == Virus::Sc2Wgs
         || args.virus == Virus::Sc2Spike
         || args.virus == Virus::Rsv
@@ -260,7 +293,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
             &dais_ref_data,
             &dais_seq_data,
             &args.runid,
-            &args.platform,
+            args.platform,
             args.virus,
         )?;
     }
@@ -292,7 +325,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     //Gather Anlysis Metadata for irma_summary
     let analysis_metadata = collect_analysis_metadata(
         &args.workdir_path,
-        &args.platform,
+        args.platform,
         args.virus,
         &args.irma_config,
         &args.qc_template,
@@ -311,40 +344,21 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &di_stats_data,
     )?;
 
-    let mut qc_values = QCSettings {
-        med_cov: 0,
-        minor_vars: 0,
-        stop_codon_restricted_proteins: String::new(),
-        perc_ref_covered: 0,
-        negative_control_perc: 0,
-        negative_control_perc_exception: 0,
-        positive_control_minimum: 0,
-        padded_consensus: false,
-        med_spike_cov: None,
-        perc_ref_spike_covered: None,
-    };
     // Set qc values based on given virus and platform
-    if args.virus == Virus::Flu {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_flu;
-        } else {
-            qc_values = qc_config.ont_flu;
+
+    let qc_values = match (args.virus, args.platform) {
+        (Virus::Flu, Platform::Illumina) => qc_config.illumina_flu,
+        (Virus::Flu, Platform::Ont) => qc_config.ont_flu,
+        (Virus::Sc2Wgs, Platform::Illumina) => qc_config.illumina_sc2,
+        (Virus::Sc2Wgs, Platform::Ont) => qc_config.ont_sc2,
+        (Virus::Sc2Spike, Platform::Illumina) => {
+            // This case is not supported, TODO ensure this
+            QCSettings::default()
         }
-    } else if args.virus == Virus::Sc2Wgs {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_sc2;
-        } else {
-            qc_values = qc_config.ont_sc2;
-        }
-    } else if args.virus == Virus::Sc2Spike {
-        qc_values = qc_config.ont_sc2_spike;
-    } else if args.virus == Virus::Rsv {
-        if args.platform.to_lowercase() == "illumina" {
-            qc_values = qc_config.illumina_rsv;
-        } else {
-            qc_values = qc_config.ont_rsv;
-        }
-    }
+        (Virus::Sc2Spike, Platform::Ont) => qc_config.ont_sc2_spike,
+        (Virus::Rsv, Platform::Illumina) => qc_config.illumina_rsv,
+        (Virus::Rsv, Platform::Ont) => qc_config.ont_rsv,
+    };
 
     // Get proteins that can not have premature stop codons
     let no_premature_stop_codon_proteins =
@@ -364,7 +378,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &irma_summary,
         args.virus,
         &args.runid,
-        &args.platform,
+        args.platform,
     )?;
 
     let aa_seq_vec = create_aa_seq_vec(
@@ -372,19 +386,19 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &irma_summary,
         args.virus,
         &args.runid,
-        &args.platform,
+        args.platform,
     )?;
 
     // Sort into passing and failing\
     let processed_aa_seq = divide_aa_into_pass_fail_vec(
         &aa_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
     let processed_nt_seq = divide_nt_into_pass_fail_vec(
         &nt_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
@@ -392,7 +406,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // Create nextclade sequence vectors for fasta files if flag given
     let nextclade_nt_seq = divide_nt_into_nextclade_vec(
         &nt_seq_vec,
-        &args.platform,
+        args.platform,
         args.virus,
         &no_premature_stop_codon_proteins,
     )?;
@@ -524,12 +538,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
                 args.runid
             ),
             &args.runid,
-            &args.platform,
+            args.platform,
         )?;
 
         // Only reading in allAlleles.txt if parquet files are being made
         let all_alleles_data =
-            all_alleles_data_collection(&args.irma_path, &args.platform, &args.runid)?;
+            all_alleles_data_collection(&args.irma_path, args.platform, &args.runid)?;
 
         write_alleles_to_parquet(
             &all_alleles_data,

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -352,8 +352,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         (Virus::Sc2Wgs, Platform::Illumina) => qc_config.illumina_sc2,
         (Virus::Sc2Wgs, Platform::Ont) => qc_config.ont_sc2,
         (Virus::Sc2Spike, Platform::Illumina) => {
-            // This case is not supported, TODO ensure this
-            QCSettings::default()
+            return Err(format!(
+                "Unhandled case for platform '{platform}' and virus '{virus}'",
+                platform = args.platform,
+                virus = args.virus
+            )
+            .into());
         }
         (Virus::Sc2Spike, Platform::Ont) => qc_config.ont_sc2_spike,
         (Virus::Rsv, Platform::Illumina) => qc_config.illumina_rsv,

--- a/src/processes/prepare_mira_reports.rs
+++ b/src/processes/prepare_mira_reports.rs
@@ -37,11 +37,13 @@ use crate::{
     },
     utils::data_processing::extract_subtype_rsv,
 };
-use clap::Parser;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
 use csv::ReaderBuilder;
 use either::Either;
 use serde::{self, Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::json;
+use std::fmt::Display;
 use std::fs;
 use std::sync::Arc;
 use std::{
@@ -75,10 +77,10 @@ pub struct ReportsArgs {
     /// Options: illumina or ont
     platform: String,
 
-    #[arg(short = 'v', long)]
+    #[arg(short = 'v', long, ignore_case = true)]
     /// The virus the the data was generated from.
     /// Options: flu, sc2-wgs, sc2-spike or rsv
-    virus: String,
+    virus: Virus,
 
     #[arg(short = 'r', long)]
     /// The run id. Used to create custom file names associated with `run_id`.
@@ -99,6 +101,43 @@ pub struct ReportsArgs {
     #[arg(short = 't', long, default_value = "")]
     /// (Optional) if a custom qc template is used for QC.
     qc_template: String,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum Virus {
+    Flu,
+    Sc2Wgs,
+    Sc2Spike,
+    Rsv,
+}
+
+impl Display for Virus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Virus::Flu => write!(f, "flu"),
+            Virus::Sc2Wgs => write!(f, "sc2-wgs"),
+            Virus::Sc2Spike => write!(f, "sc2-spike"),
+            Virus::Rsv => write!(f, "rsv"),
+        }
+    }
+}
+
+// Allows case insensitivity for trim ends
+impl ValueEnum for Virus {
+    #[inline]
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Flu, Self::Sc2Wgs, Self::Sc2Spike, Self::Rsv]
+    }
+
+    #[inline]
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Virus::Flu => Some(PossibleValue::new("flu")),
+            Virus::Sc2Wgs => Some(PossibleValue::new("sc2-wgs")),
+            Virus::Sc2Spike => Some(PossibleValue::new("sc2-spike")),
+            Virus::Rsv => Some(PossibleValue::new("rsv")),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -172,14 +211,14 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
 
     // Read in IRMA data
     let coverage_data =
-        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, &args.virus)?;
+        coverage_data_collection(&args.irma_path, &args.platform, &args.runid, args.virus)?;
     let read_data = reads_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let vtype_data = create_vtype_data(&read_data);
     let minor_variant_data =
         minor_variant_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let indel_data = indels_data_collection(&args.irma_path, &args.platform, &args.runid)?;
     let run_info = run_info_collection(&args.irma_path, &args.platform, &args.runid)?;
-    let seq_data = amended_consensus_data_collection(&args.irma_path, &args.virus)?;
+    let seq_data = amended_consensus_data_collection(&args.irma_path, args.virus)?;
     let ref_lengths = match get_reference_lens(&args.irma_path) {
         Ok(data) => data,
         Err(e) => {
@@ -196,9 +235,9 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // In MIRA-NF the DAIS outputs are fed right to the working directory to be used in this step
     let dais_seq_data = dais_sequence_data_collection("./")?;
     let mut dais_ref_data: Vec<DaisSeqData> = Vec::new();
-    if args.virus.to_lowercase() == "flu" || args.virus.to_lowercase() == "rsv" {
-        dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, &args.virus)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" || args.virus.to_lowercase() == "sc2-spike" {
+    if args.virus == Virus::Flu || args.virus == Virus::Rsv {
+        dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, args.virus)?;
+    } else if args.virus == Virus::Sc2Wgs || args.virus == Virus::Sc2Spike {
         dais_ref_data = dais_ref_seq_data_collection(&args.workdir_path, "sc2")?;
     }
 
@@ -211,19 +250,19 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     //////////////////////////////// Processing ingested IRMA and Dais data ////////////////////////////////
     // Calculate AA variants for aavars.csv and dais_vars.json
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         dais_vars_data =
             compute_dais_variants(&dais_ref_data, &dais_seq_data, &args.runid, &args.platform)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs"
-        || args.virus.to_lowercase() == "sc2-spike"
-        || args.virus.to_lowercase() == "rsv"
+    } else if args.virus == Virus::Sc2Wgs
+        || args.virus == Virus::Sc2Spike
+        || args.virus == Virus::Rsv
     {
         dais_vars_data = compute_cvv_dais_variants(
             &dais_ref_data,
             &dais_seq_data,
             &args.runid,
             &args.platform,
-            &args.virus,
+            args.virus,
         )?;
     }
 
@@ -232,22 +271,22 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let mut calculated_cov_vec: Vec<ProcessedCoverage> = Vec::new();
     let mut calculated_position_cov_vec: Vec<ProcessedCoverage> = Vec::new();
 
-    if args.virus.to_lowercase() == "flu" || args.virus.to_lowercase() == "rsv" {
+    if args.virus == Virus::Flu || args.virus == Virus::Rsv {
         calculated_cov_vec = process_wgs_coverage_data(&coverage_data, &ref_lengths)?;
-    } else if args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Spike {
         calculated_cov_vec = process_position_coverage_data(&coverage_data, 21563, 25384)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" {
+    } else if args.virus == Virus::Sc2Wgs {
         calculated_cov_vec = process_wgs_coverage_data(&coverage_data, &ref_lengths)?;
         calculated_position_cov_vec = process_position_coverage_data(&coverage_data, 21563, 25384)?;
     }
 
     //Gather subtype information
     let mut subtype_data: Vec<Subtype> = Vec::new();
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         subtype_data = extract_subtype_flu(&dais_vars_data, &calculated_cov_vec)?;
-    } else if args.virus.to_lowercase() == "sc2-wgs" || args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Wgs || args.virus == Virus::Sc2Spike {
         subtype_data = extract_subtype_sc2(&dais_vars_data)?;
-    } else if args.virus.to_lowercase() == "rsv" {
+    } else if args.virus == Virus::Rsv {
         subtype_data = extract_subtype_rsv(&dais_vars_data)?;
     }
 
@@ -255,7 +294,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let analysis_metadata = collect_analysis_metadata(
         &args.workdir_path,
         &args.platform,
-        &args.virus,
+        args.virus,
         &args.irma_config,
         &args.qc_template,
         &args.runid,
@@ -286,21 +325,21 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         perc_ref_spike_covered: None,
     };
     // Set qc values based on given virus and platform
-    if args.virus.to_lowercase() == "flu" {
+    if args.virus == Virus::Flu {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_flu;
         } else {
             qc_values = qc_config.ont_flu;
         }
-    } else if args.virus.to_lowercase() == "sc2-wgs" {
+    } else if args.virus == Virus::Sc2Wgs {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_sc2;
         } else {
             qc_values = qc_config.ont_sc2;
         }
-    } else if args.virus.to_lowercase() == "sc2-spike" {
+    } else if args.virus == Virus::Sc2Spike {
         qc_values = qc_config.ont_sc2_spike;
-    } else if args.virus.to_lowercase() == "rsv" {
+    } else if args.virus == Virus::Rsv {
         if args.platform.to_lowercase() == "illumina" {
             qc_values = qc_config.illumina_rsv;
         } else {
@@ -315,7 +354,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     // Add pass fail information to irma summary
     for sample in &mut irma_summary {
         if sample.pass_fail_reason.is_none() {
-            sample.add_pass_fail_qc(&dais_vars_data, &args.virus, &qc_values)?;
+            sample.add_pass_fail_qc(&dais_vars_data, args.virus, &qc_values)?;
         }
     }
 
@@ -324,7 +363,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &seq_data,
         &vtype_data,
         &irma_summary,
-        &args.virus,
+        args.virus,
         &args.runid,
         &args.platform,
     )?;
@@ -332,7 +371,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let aa_seq_vec = create_aa_seq_vec(
         &dais_seq_data,
         &irma_summary,
-        &args.virus,
+        args.virus,
         &args.runid,
         &args.platform,
     )?;
@@ -341,13 +380,13 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let processed_aa_seq = divide_aa_into_pass_fail_vec(
         &aa_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
     let processed_nt_seq = divide_nt_into_pass_fail_vec(
         &nt_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
 
@@ -355,12 +394,12 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let nextclade_nt_seq = divide_nt_into_nextclade_vec(
         &nt_seq_vec,
         &args.platform,
-        &args.virus,
+        args.virus,
         &no_premature_stop_codon_proteins,
     )?;
 
     // Processing data for Dashboard Figures
-    let transformed_cov_data = transform_coverage_to_heatmap(&coverage_data, &args.virus);
+    let transformed_cov_data = transform_coverage_to_heatmap(&coverage_data, args.virus);
 
     //////////////////////////////// Write all files ////////////////////////////////
     println!("Writing Output Files...");
@@ -391,7 +430,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &aa_seq_vec,
         &run_info,
         &args.runid,
-        &args.virus,
+        args.virus,
     )?;
 
     println!("Writing JSON files");
@@ -406,7 +445,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &neg_control_list,
         &irma_summary,
         &nt_seq_vec,
-        &args.virus,
+        args.virus,
     )?;
 
     // Write fields to parq if flag given
@@ -447,7 +486,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         )?;
         write_irma_summary_to_parquet(
             &irma_summary,
-            &args.virus,
+            args.virus,
             &format!(
                 "{}/mira_{}_summary.parq",
                 args.output_path.display(),
@@ -508,27 +547,27 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
     let coverage_json_per_sample = create_coverage_plot(
         &coverage_data,
         segments,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     )?;
 
     let sankey_json_per_sample = reads_to_sankey_json(
         &read_data,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
     let cov_heatmap_json = coverage_to_heatmap_json(
         &transformed_cov_data,
         &sample_list,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
     let pass_fail_heatmap_json = create_passfail_heatmap(
         &irma_summary,
         &sample_list,
-        &args.virus,
+        args.virus,
         &format!("{}/", args.output_path.display()),
     );
 
@@ -549,7 +588,7 @@ pub fn prepare_mira_reports_process(args: &ReportsArgs) -> Result<(), Box<dyn Er
         &sankey_json_per_sample,
         &args.runid,
         Some(&args.workdir_path),
-        &args.virus,
+        args.virus,
     );
 
     Ok(())

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use crate::processes::prepare_mira_reports::SamplesheetO;
+use crate::processes::prepare_mira_reports::{SamplesheetO, Virus};
 use crate::{io::data_ingest::DIStatData, processes::prepare_mira_reports::SamplesheetI};
 
 use crate::io::data_ingest::{
@@ -431,12 +431,12 @@ pub fn compute_cvv_dais_variants(
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
     instrument: &str,
-    virus: &str,
+    virus: Virus,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut merged_data = merge_sequences(ref_seqs_data, sample_seqs_data);
 
     // Filter dais var data based on virus type
-    if virus == "sc2-spike" {
+    if virus == Virus::Sc2Spike {
         merged_data.retain(|entry| entry.protein == "S");
     }
 
@@ -924,7 +924,7 @@ pub fn count_minor_variants(data: &[MinorVariantsData]) -> Vec<VariantCountData>
 pub fn collect_analysis_metadata(
     work_path: &Path,
     platform: &str,
-    virus: &str,
+    virus: Virus,
     irma_config: &String,
     input_runid: &str,
 ) -> Result<Metadata, Box<dyn Error>> {
@@ -1082,7 +1082,7 @@ impl IRMASummary {
     pub fn add_pass_fail_qc(
         &mut self,
         dais_vars: &[DaisVarsData],
-        virus: &str,
+        virus: Virus,
         qc_values: &QCSettings,
     ) -> Result<Vec<IRMASummary>, Box<dyn Error>> {
         let irma_summary: Vec<IRMASummary> = Vec::new();
@@ -1092,7 +1092,7 @@ impl IRMASummary {
                 .iter()
                 .filter(|entry| {
                     // Handle sample_id comparison based on virus type
-                    let sample_match = if virus == "flu" {
+                    let sample_match = if virus == Virus::Flu {
                         // Take the last two characters off entry.sample_id before comparing
                         let entry_id = &entry.sample_id;
 
@@ -1206,13 +1206,13 @@ pub fn create_nt_seq_vec(
     seq_data: &[SeqData],
     vtype_vec: &[ProcessedRecord],
     irma_summary_vec: &[IRMASummary],
-    virus: &str,
+    virus: Virus,
     runid: &str,
     instrument: &str,
 ) -> Result<Vec<NTSequences>, Box<dyn Error>> {
     let mut nt_seq_vec: Vec<NTSequences> = Vec::new();
 
-    if virus == "flu" {
+    if virus == Virus::Flu {
         //Split name and segemnt unmber by last underscore
         for entry in seq_data {
             let parts: Vec<&str> = entry.name.rsplitn(2, '_').collect();
@@ -1308,7 +1308,7 @@ pub fn create_nt_seq_vec(
 pub fn divide_nt_into_pass_fail_vec(
     nt_seq_vec: &[NTSequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
     let mut pass_vec: Vec<SeqData> = Vec::new();
@@ -1324,7 +1324,7 @@ pub fn divide_nt_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu" | "sc2-wgs" | "rsv") | ("ont", _) => {
+                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
@@ -1365,13 +1365,13 @@ pub fn divide_nt_into_pass_fail_vec(
 pub fn create_aa_seq_vec(
     aa_data: &[DaisSeqData],
     irma_summary_vec: &[IRMASummary],
-    virus: &str,
+    virus: Virus,
     runid: &str,
     instrument: &str,
 ) -> Result<Vec<AASequences>, Box<dyn Error>> {
     let mut aa_seq_vec: Vec<AASequences> = Vec::new();
 
-    if virus == "flu" {
+    if virus == Virus::Flu {
         for entry in aa_data {
             let parts: Vec<&str> = entry.sample_id.rsplitn(2, '_').collect();
             if parts.len() != 2 {
@@ -1421,7 +1421,7 @@ pub fn create_aa_seq_vec(
 pub fn divide_aa_into_pass_fail_vec(
     nt_seq_vec: &[AASequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
     let mut pass_vec: Vec<SeqData> = Vec::new();
@@ -1437,7 +1437,7 @@ pub fn divide_aa_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu" | "sc2-wgs" | "rsv") | ("ont", _) => {
+                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
@@ -1485,7 +1485,7 @@ pub fn divide_aa_into_pass_fail_vec(
 pub fn divide_nt_into_nextclade_vec(
     nt_seq_vec: &[NTSequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<NextcladeSequences, Box<dyn Error>> {
     let mut nextclade_seqs = NextcladeSequences {
@@ -1510,20 +1510,20 @@ pub fn divide_nt_into_nextclade_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu") => {
+                ("illumina", Virus::Flu) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains("HA")
                             && !entry.reference.contains("NA"))
                 }
-                ("illumina", "sc2-wgs") => {
+                ("illumina", Virus::Sc2Wgs) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.qc_decision.contains("Premature stop codon 'S'"))
                 }
-                ("illumina", "rsv") => {
+                ("illumina", Virus::Rsv) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
@@ -1577,13 +1577,13 @@ pub fn divide_nt_into_nextclade_vec(
 #[must_use]
 pub fn transform_coverage_to_heatmap(
     coverage_data: &[CoverageData],
-    virus: &str,
+    virus: Virus,
 ) -> Vec<TransformedData> {
     // Filter for SC2-Spike region if virus is "sc2-spike"
     let position_1 = 21563;
     let position_2 = 25384;
 
-    let filtered_data: Vec<&CoverageData> = if virus.to_lowercase() == "sc2-spike" {
+    let filtered_data: Vec<&CoverageData> = if virus == Virus::Sc2Spike {
         coverage_data
             .iter()
             .filter(|row| row.position > position_1 && row.position < position_2)

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use crate::processes::prepare_mira_reports::{SamplesheetO, Virus};
+use crate::processes::prepare_mira_reports::{Platform, SamplesheetO, Virus};
 use crate::{io::data_ingest::DIStatData, processes::prepare_mira_reports::SamplesheetI};
 
 use crate::io::data_ingest::{
@@ -359,7 +359,7 @@ pub fn compute_dais_variants(
     ref_seqs_data: &[DaisSeqData],
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
 
@@ -395,7 +395,7 @@ pub fn compute_dais_variants(
                     aa_variant_count: var_aa_count,
                     aa_variants: aa_vars,
                     runid: runid.to_owned(),
-                    instrument: instrument.to_owned(),
+                    instrument: instrument.to_string(),
                 };
                 dais_vars_data.push(dais_vars_entry);
             }
@@ -430,7 +430,7 @@ pub fn compute_cvv_dais_variants(
     ref_seqs_data: &[DaisSeqData],
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
     virus: Virus,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut merged_data = merge_sequences(ref_seqs_data, sample_seqs_data);
@@ -484,7 +484,7 @@ pub fn compute_cvv_dais_variants(
             aa_variant_count: num_variants as i32,
             aa_variants: entry.insertion.clone(),
             runid: runid.to_owned(),
-            instrument: instrument.to_owned(),
+            instrument: instrument.to_string(),
         })
         .collect();
 
@@ -923,7 +923,7 @@ pub fn count_minor_variants(data: &[MinorVariantsData]) -> Vec<VariantCountData>
 
 pub fn collect_analysis_metadata(
     work_path: &Path,
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     irma_config: &String,
     input_runid: &str,
@@ -953,7 +953,7 @@ pub fn collect_analysis_metadata(
     let analysis_metadata = Metadata {
         module: modulestring,
         runid: input_runid.to_owned(),
-        instrument: platform.to_owned(),
+        instrument: platform.to_string(),
     };
     Ok(analysis_metadata)
 }
@@ -1208,7 +1208,7 @@ pub fn create_nt_seq_vec(
     irma_summary_vec: &[IRMASummary],
     virus: Virus,
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<NTSequences>, Box<dyn Error>> {
     let mut nt_seq_vec: Vec<NTSequences> = Vec::new();
 
@@ -1276,7 +1276,7 @@ pub fn create_nt_seq_vec(
                                     .clone()
                                     .unwrap_or_else(String::new),
                                 runid: runid.to_owned(),
-                                instrument: instrument.to_owned(),
+                                instrument: instrument.to_string(),
                             });
                         }
                     }
@@ -1294,7 +1294,7 @@ pub fn create_nt_seq_vec(
                         reference: record.reference.clone().unwrap_or(String::new()),
                         qc_decision: record.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1307,7 +1307,7 @@ pub fn create_nt_seq_vec(
 //Pre step for printing the pass/fail amended concensus
 pub fn divide_nt_into_pass_fail_vec(
     nt_seq_vec: &[NTSequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
@@ -1324,12 +1324,13 @@ pub fn divide_nt_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
+                (Platform::Illumina, Virus::Flu | Virus::Sc2Wgs | Virus::Rsv)
+                | (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )
@@ -1367,7 +1368,7 @@ pub fn create_aa_seq_vec(
     irma_summary_vec: &[IRMASummary],
     virus: Virus,
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<AASequences>, Box<dyn Error>> {
     let mut aa_seq_vec: Vec<AASequences> = Vec::new();
 
@@ -1389,7 +1390,7 @@ pub fn create_aa_seq_vec(
                         reference: sample.reference.clone().unwrap_or_else(String::new),
                         qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1407,7 +1408,7 @@ pub fn create_aa_seq_vec(
                         reference: sample.reference.clone().unwrap_or_else(String::new),
                         qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1420,7 +1421,7 @@ pub fn create_aa_seq_vec(
 //Pre step for printing the pass/fail amino acid concensus
 pub fn divide_aa_into_pass_fail_vec(
     nt_seq_vec: &[AASequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
@@ -1437,12 +1438,13 @@ pub fn divide_aa_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
+                (Platform::Illumina, Virus::Flu | Virus::Sc2Wgs | Virus::Rsv)
+                | (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )
@@ -1484,7 +1486,7 @@ pub fn divide_aa_into_pass_fail_vec(
 // Creating seq vecs for nextclade fastas
 pub fn divide_nt_into_nextclade_vec(
     nt_seq_vec: &[NTSequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<NextcladeSequences, Box<dyn Error>> {
@@ -1510,32 +1512,32 @@ pub fn divide_nt_into_nextclade_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu) => {
+                (Platform::Illumina, Virus::Flu) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains("HA")
                             && !entry.reference.contains("NA"))
                 }
-                ("illumina", Virus::Sc2Wgs) => {
+                (Platform::Illumina, Virus::Sc2Wgs) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.qc_decision.contains("Premature stop codon 'S'"))
                 }
-                ("illumina", Virus::Rsv) => {
+                (Platform::Illumina, Virus::Rsv) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains('F')
                             && !entry.reference.contains('G'))
                 }
-                ("ont", _) => {
+                (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use crate::processes::prepare_mira_reports::SamplesheetO;
+use crate::processes::prepare_mira_reports::{SamplesheetO, Virus};
 use crate::{io::data_ingest::DIStatData, processes::prepare_mira_reports::SamplesheetI};
 
 use crate::io::data_ingest::{
@@ -432,12 +432,12 @@ pub fn compute_cvv_dais_variants(
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
     instrument: &str,
-    virus: &str,
+    virus: Virus,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut merged_data = merge_sequences(ref_seqs_data, sample_seqs_data);
 
     // Filter dais var data based on virus type
-    if virus == "sc2-spike" {
+    if virus == Virus::Sc2Spike {
         merged_data.retain(|entry| entry.protein == "S");
     }
 
@@ -925,7 +925,7 @@ pub fn count_minor_variants(data: &[MinorVariantsData]) -> Vec<VariantCountData>
 pub fn collect_analysis_metadata(
     work_path: &Path,
     platform: &str,
-    virus: &str,
+    virus: Virus,
     irma_config: &String,
     qc_template: &String,
     input_runid: &str,
@@ -1088,7 +1088,7 @@ impl IRMASummary {
     pub fn add_pass_fail_qc(
         &mut self,
         dais_vars: &[DaisVarsData],
-        virus: &str,
+        virus: Virus,
         qc_values: &QCSettings,
     ) -> Result<Vec<IRMASummary>, Box<dyn Error>> {
         let irma_summary: Vec<IRMASummary> = Vec::new();
@@ -1098,7 +1098,7 @@ impl IRMASummary {
                 .iter()
                 .filter(|entry| {
                     // Handle sample_id comparison based on virus type
-                    let sample_match = if virus == "flu" {
+                    let sample_match = if virus == Virus::Flu {
                         // Take the last two characters off entry.sample_id before comparing
                         let entry_id = &entry.sample_id;
 
@@ -1212,13 +1212,13 @@ pub fn create_nt_seq_vec(
     seq_data: &[SeqData],
     vtype_vec: &[ProcessedRecord],
     irma_summary_vec: &[IRMASummary],
-    virus: &str,
+    virus: Virus,
     runid: &str,
     instrument: &str,
 ) -> Result<Vec<NTSequences>, Box<dyn Error>> {
     let mut nt_seq_vec: Vec<NTSequences> = Vec::new();
 
-    if virus == "flu" {
+    if virus == Virus::Flu {
         //Split name and segemnt unmber by last underscore
         for entry in seq_data {
             let parts: Vec<&str> = entry.name.rsplitn(2, '_').collect();
@@ -1314,7 +1314,7 @@ pub fn create_nt_seq_vec(
 pub fn divide_nt_into_pass_fail_vec(
     nt_seq_vec: &[NTSequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
     let mut pass_vec: Vec<SeqData> = Vec::new();
@@ -1330,7 +1330,7 @@ pub fn divide_nt_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu" | "sc2-wgs" | "rsv") | ("ont", _) => {
+                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
@@ -1371,13 +1371,13 @@ pub fn divide_nt_into_pass_fail_vec(
 pub fn create_aa_seq_vec(
     aa_data: &[DaisSeqData],
     irma_summary_vec: &[IRMASummary],
-    virus: &str,
+    virus: Virus,
     runid: &str,
     instrument: &str,
 ) -> Result<Vec<AASequences>, Box<dyn Error>> {
     let mut aa_seq_vec: Vec<AASequences> = Vec::new();
 
-    if virus == "flu" {
+    if virus == Virus::Flu {
         for entry in aa_data {
             let parts: Vec<&str> = entry.sample_id.rsplitn(2, '_').collect();
             if parts.len() != 2 {
@@ -1427,7 +1427,7 @@ pub fn create_aa_seq_vec(
 pub fn divide_aa_into_pass_fail_vec(
     nt_seq_vec: &[AASequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
     let mut pass_vec: Vec<SeqData> = Vec::new();
@@ -1443,7 +1443,7 @@ pub fn divide_aa_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu" | "sc2-wgs" | "rsv") | ("ont", _) => {
+                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
@@ -1491,7 +1491,7 @@ pub fn divide_aa_into_pass_fail_vec(
 pub fn divide_nt_into_nextclade_vec(
     nt_seq_vec: &[NTSequences],
     platform: &str,
-    virus: &str,
+    virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<NextcladeSequences, Box<dyn Error>> {
     let mut nextclade_seqs = NextcladeSequences {
@@ -1516,20 +1516,20 @@ pub fn divide_nt_into_nextclade_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", "flu") => {
+                ("illumina", Virus::Flu) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains("HA")
                             && !entry.reference.contains("NA"))
                 }
-                ("illumina", "sc2-wgs") => {
+                ("illumina", Virus::Sc2Wgs) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.qc_decision.contains("Premature stop codon 'S'"))
                 }
-                ("illumina", "rsv") => {
+                ("illumina", Virus::Rsv) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
@@ -1583,13 +1583,13 @@ pub fn divide_nt_into_nextclade_vec(
 #[must_use]
 pub fn transform_coverage_to_heatmap(
     coverage_data: &[CoverageData],
-    virus: &str,
+    virus: Virus,
 ) -> Vec<TransformedData> {
     // Filter for SC2-Spike region if virus is "sc2-spike"
     let position_1 = 21563;
     let position_2 = 25384;
 
-    let filtered_data: Vec<&CoverageData> = if virus.to_lowercase() == "sc2-spike" {
+    let filtered_data: Vec<&CoverageData> = if virus == Virus::Sc2Spike {
         coverage_data
             .iter()
             .filter(|row| row.position > position_1 && row.position < position_2)

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use crate::processes::prepare_mira_reports::{SamplesheetO, Virus};
+use crate::processes::prepare_mira_reports::{Platform, SamplesheetO, Virus};
 use crate::{io::data_ingest::DIStatData, processes::prepare_mira_reports::SamplesheetI};
 
 use crate::io::data_ingest::{
@@ -359,7 +359,7 @@ pub fn compute_dais_variants(
     ref_seqs_data: &[DaisSeqData],
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut dais_vars_data: Vec<DaisVarsData> = Vec::new();
 
@@ -395,7 +395,7 @@ pub fn compute_dais_variants(
                     aa_variant_count: var_aa_count,
                     aa_variants: aa_vars,
                     runid: runid.to_owned(),
-                    instrument: instrument.to_owned(),
+                    instrument: instrument.to_string(),
                 };
                 dais_vars_data.push(dais_vars_entry);
             }
@@ -431,7 +431,7 @@ pub fn compute_cvv_dais_variants(
     ref_seqs_data: &[DaisSeqData],
     sample_seqs_data: &[DaisSeqData],
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
     virus: Virus,
 ) -> Result<Vec<DaisVarsData>, Box<dyn Error>> {
     let mut merged_data = merge_sequences(ref_seqs_data, sample_seqs_data);
@@ -485,7 +485,7 @@ pub fn compute_cvv_dais_variants(
             aa_variant_count: num_variants as i32,
             aa_variants: entry.insertion.clone(),
             runid: runid.to_owned(),
-            instrument: instrument.to_owned(),
+            instrument: instrument.to_string(),
         })
         .collect();
 
@@ -924,7 +924,7 @@ pub fn count_minor_variants(data: &[MinorVariantsData]) -> Vec<VariantCountData>
 
 pub fn collect_analysis_metadata(
     work_path: &Path,
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     irma_config: &String,
     qc_template: &String,
@@ -959,7 +959,7 @@ pub fn collect_analysis_metadata(
     let analysis_metadata = Metadata {
         module: modulestring,
         runid: input_runid.to_owned(),
-        instrument: platform.to_owned(),
+        instrument: platform.to_string(),
     };
     Ok(analysis_metadata)
 }
@@ -1214,7 +1214,7 @@ pub fn create_nt_seq_vec(
     irma_summary_vec: &[IRMASummary],
     virus: Virus,
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<NTSequences>, Box<dyn Error>> {
     let mut nt_seq_vec: Vec<NTSequences> = Vec::new();
 
@@ -1282,7 +1282,7 @@ pub fn create_nt_seq_vec(
                                     .clone()
                                     .unwrap_or_else(String::new),
                                 runid: runid.to_owned(),
-                                instrument: instrument.to_owned(),
+                                instrument: instrument.to_string(),
                             });
                         }
                     }
@@ -1300,7 +1300,7 @@ pub fn create_nt_seq_vec(
                         reference: record.reference.clone().unwrap_or(String::new()),
                         qc_decision: record.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1313,7 +1313,7 @@ pub fn create_nt_seq_vec(
 //Pre step for printing the pass/fail amended concensus
 pub fn divide_nt_into_pass_fail_vec(
     nt_seq_vec: &[NTSequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
@@ -1330,12 +1330,13 @@ pub fn divide_nt_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
+                (Platform::Illumina, Virus::Flu | Virus::Sc2Wgs | Virus::Rsv)
+                | (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )
@@ -1373,7 +1374,7 @@ pub fn create_aa_seq_vec(
     irma_summary_vec: &[IRMASummary],
     virus: Virus,
     runid: &str,
-    instrument: &str,
+    instrument: Platform,
 ) -> Result<Vec<AASequences>, Box<dyn Error>> {
     let mut aa_seq_vec: Vec<AASequences> = Vec::new();
 
@@ -1395,7 +1396,7 @@ pub fn create_aa_seq_vec(
                         reference: sample.reference.clone().unwrap_or_else(String::new),
                         qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1413,7 +1414,7 @@ pub fn create_aa_seq_vec(
                         reference: sample.reference.clone().unwrap_or_else(String::new),
                         qc_decision: sample.pass_fail_reason.clone().unwrap_or_else(String::new),
                         runid: runid.to_owned(),
-                        instrument: instrument.to_owned(),
+                        instrument: instrument.to_string(),
                     });
                 }
             }
@@ -1426,7 +1427,7 @@ pub fn create_aa_seq_vec(
 //Pre step for printing the pass/fail amino acid concensus
 pub fn divide_aa_into_pass_fail_vec(
     nt_seq_vec: &[AASequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<ProcessedSequences, Box<dyn Error>> {
@@ -1443,12 +1444,13 @@ pub fn divide_aa_into_pass_fail_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu | Virus::Sc2Wgs | Virus::Rsv) | ("ont", _) => {
+                (Platform::Illumina, Virus::Flu | Virus::Sc2Wgs | Virus::Rsv)
+                | (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )
@@ -1490,7 +1492,7 @@ pub fn divide_aa_into_pass_fail_vec(
 // Creating seq vecs for nextclade fastas
 pub fn divide_nt_into_nextclade_vec(
     nt_seq_vec: &[NTSequences],
-    platform: &str,
+    platform: Platform,
     virus: Virus,
     no_premature_stop_codon_proteins: &[String],
 ) -> Result<NextcladeSequences, Box<dyn Error>> {
@@ -1516,32 +1518,32 @@ pub fn divide_nt_into_nextclade_vec(
             false
         } else {
             match (platform, virus) {
-                ("illumina", Virus::Flu) => {
+                (Platform::Illumina, Virus::Flu) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains("HA")
                             && !entry.reference.contains("NA"))
                 }
-                ("illumina", Virus::Sc2Wgs) => {
+                (Platform::Illumina, Virus::Sc2Wgs) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.qc_decision.contains("Premature stop codon 'S'"))
                 }
-                ("illumina", Virus::Rsv) => {
+                (Platform::Illumina, Virus::Rsv) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';')
                             && !entry.reference.contains('F')
                             && !entry.reference.contains('G'))
                 }
-                ("ont", _) => {
+                (Platform::Ont, _) => {
                     entry.qc_decision == "Pass"
                         || (entry.qc_decision.contains("Premature stop codon")
                             && !entry.qc_decision.contains(';'))
                 }
-                _ => {
+                (Platform::Illumina, Virus::Sc2Spike) => {
                     return Err(format!(
                         "Unhandled case for platform '{platform}' and virus '{virus}'"
                     )


### PR DESCRIPTION
Throughout the code, there are multiple areas where the behavior differs based on the virus used. This is currently handled by doing string comparison, sometimes case sensitively and sometimes case insensitively. This could lead to weird behavior if the virus name is passed in uppercase, where some comparisons work and some don't.

This PR makes the code more robust by using an enum. The following changes occur as a result:
- The virus name is completely parsed without regard to case, which fixes some potential edge cases
- If a virus name other than "flu", "sc2-wgs", "sc2-spike", or "rsv" is provided, it will error out immediately. This is a change in behavior that I think is desirable, but needs to be verified
- Clap now automatically lists the possible values, rather than us having to in the docs.
- The virus name is now always displayed in lowercase, not in the case provided by the user