### PR TITLE
Remove Option around sample_id for CoverageData

### DIFF
--- a/src/io/coverage_json_per_sample.rs
+++ b/src/io/coverage_json_per_sample.rs
@@ -24,10 +24,7 @@ pub fn create_sample_coverage_fig(
     let mut plot = Plot::new();
 
     // Filter data for the given sample
-    let sample_data: Vec<&CoverageData> = data
-        .iter()
-        .filter(|d| d.sample_id.as_deref() == Some(sample))
-        .collect();
+    let sample_data: Vec<&CoverageData> = data.iter().filter(|d| d.sample_id == sample).collect();
 
     if sample_data.is_empty() {
         return Ok(plot);
@@ -260,7 +257,7 @@ pub fn create_coverage_plot(
 ) -> Result<Vec<SampleCoverageJson>, Box<dyn Error>> {
     let samples: Vec<String> = data
         .iter()
-        .filter_map(|d| d.sample_id.clone())
+        .map(|d| d.sample_id.clone())
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+use zoe::iter_utils::ProcessResultsExt;
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
@@ -62,10 +63,8 @@ where
 }
 
 /// Coverage struct
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CoverageData {
-    #[serde(rename = "Sample")]
-    pub sample_id: Option<String>,
+#[derive(Clone, Debug, Deserialize)]
+struct CoverageDataNoId {
     #[serde(rename = "Reference_Name")]
     pub reference_name: String,
     #[serde(rename = "Position")]
@@ -89,6 +88,57 @@ pub struct CoverageData {
     pub run_id: Option<String>,
     #[serde(rename = "Instrument")]
     pub instrument: Option<String>,
+}
+
+/// Coverage struct
+#[derive(Serialize, Debug, Clone)]
+pub struct CoverageData {
+    #[serde(rename = "Sample")]
+    pub sample_id: String,
+    #[serde(rename = "Reference_Name")]
+    pub reference_name: String,
+    #[serde(rename = "Position")]
+    #[serde(deserialize_with = "string_to_int")]
+    pub position: i32,
+    #[serde(rename = "Coverage Depth")]
+    pub coverage_depth: i32,
+    #[serde(rename = "Consensus")]
+    pub consensus: String,
+    #[serde(rename = "Deletions")]
+    pub deletions: i32,
+    #[serde(rename = "Ambiguous")]
+    pub ambiguous: i32,
+    #[serde(rename = "Consensus_Count")]
+    pub consensus_count: i32,
+    #[serde(rename = "Consensus_Average_Quality")]
+    pub consensus_avg_quality: f64,
+    #[serde(rename = "HMM_Position")]
+    pub hmm_position: Option<i32>,
+    #[serde(rename = "Run_ID")]
+    pub run_id: Option<String>,
+    #[serde(rename = "Instrument")]
+    pub instrument: Option<String>,
+}
+
+impl DeserializeWithSampleId for CoverageData {
+    type NoId = CoverageDataNoId;
+
+    fn set_sample_id(no_id: Self::NoId, sample_id: &str) -> Self {
+        Self {
+            sample_id: sample_id.to_string(),
+            reference_name: no_id.reference_name,
+            position: no_id.position,
+            coverage_depth: no_id.coverage_depth,
+            consensus: no_id.consensus,
+            deletions: no_id.deletions,
+            ambiguous: no_id.ambiguous,
+            consensus_count: no_id.consensus_count,
+            consensus_avg_quality: no_id.consensus_avg_quality,
+            hmm_position: no_id.hmm_position,
+            run_id: no_id.run_id,
+            instrument: no_id.instrument,
+        }
+    }
 }
 
 /// Reads struct
@@ -316,6 +366,30 @@ pub struct NextcladeData {
     pub sample_id: Option<String>,
 }
 
+trait DeserializeWithSampleId: Sized {
+    type NoId: for<'de> Deserialize<'de>;
+
+    fn set_sample_id(no_id: Self::NoId, sample_id: &str) -> Self;
+
+    /// Read tab-delimited data and include the sample name
+    fn parse<R: Read>(
+        reader: R,
+        has_headers: bool,
+        sample_id: &str,
+    ) -> Result<Vec<Self>, csv::Error> {
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(has_headers)
+            .delimiter(b'\t')
+            .from_reader(reader);
+
+        rdr.deserialize().process_results(|records| {
+            records
+                .map(|record| Self::set_sample_id(record, sample_id))
+                .collect::<Vec<_>>()
+        })
+    }
+}
+
 /////////////// Imp for the process_txt_with_sample_function ///////////////
 /// Define a trait for structs that have a `sample_id` field
 trait GetSampleId {
@@ -325,7 +399,7 @@ trait GetSampleId {
 // Implement the trait for CoverageData
 impl GetSampleId for CoverageData {
     fn set_sample_id(&mut self, sample_id: String) {
-        self.sample_id = Some(sample_id);
+        self.sample_id = sample_id;
     }
 }
 
@@ -510,8 +584,7 @@ pub fn coverage_data_collection(
                 let reader = BufReader::new(file);
 
                 // Read the data from the file and include the sample name
-                let mut records: Vec<CoverageData> =
-                    process_txt_with_sample(reader, true, &sample)?;
+                let mut records = CoverageData::parse(reader, true, &sample)?;
 
                 // If virus is "sc2-spike", replace position with hmm_position
                 if virus == "sc2-spike" {

--- a/src/io/data_ingest.rs
+++ b/src/io/data_ingest.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+use zoe::iter_utils::ProcessResultsExt;
 
 /////////////// Structs to hold IRMA data ///////////////
 ///
@@ -62,10 +63,8 @@ where
 }
 
 /// Coverage struct
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CoverageData {
-    #[serde(rename = "Sample")]
-    pub sample_id: Option<String>,
+#[derive(Clone, Debug, Deserialize)]
+struct CoverageDataNoId {
     #[serde(rename = "Reference_Name")]
     pub reference_name: String,
     #[serde(rename = "Position")]
@@ -89,6 +88,57 @@ pub struct CoverageData {
     pub run_id: Option<String>,
     #[serde(rename = "Instrument")]
     pub instrument: Option<String>,
+}
+
+/// Coverage struct
+#[derive(Serialize, Debug, Clone)]
+pub struct CoverageData {
+    #[serde(rename = "Sample")]
+    pub sample_id: String,
+    #[serde(rename = "Reference_Name")]
+    pub reference_name: String,
+    #[serde(rename = "Position")]
+    #[serde(deserialize_with = "string_to_int")]
+    pub position: i32,
+    #[serde(rename = "Coverage Depth")]
+    pub coverage_depth: i32,
+    #[serde(rename = "Consensus")]
+    pub consensus: String,
+    #[serde(rename = "Deletions")]
+    pub deletions: i32,
+    #[serde(rename = "Ambiguous")]
+    pub ambiguous: i32,
+    #[serde(rename = "Consensus_Count")]
+    pub consensus_count: i32,
+    #[serde(rename = "Consensus_Average_Quality")]
+    pub consensus_avg_quality: f64,
+    #[serde(rename = "HMM_Position")]
+    pub hmm_position: Option<i32>,
+    #[serde(rename = "Run_ID")]
+    pub run_id: Option<String>,
+    #[serde(rename = "Instrument")]
+    pub instrument: Option<String>,
+}
+
+impl DeserializeWithSampleId for CoverageData {
+    type NoId = CoverageDataNoId;
+
+    fn set_sample_id(no_id: Self::NoId, sample_id: &str) -> Self {
+        Self {
+            sample_id: sample_id.to_string(),
+            reference_name: no_id.reference_name,
+            position: no_id.position,
+            coverage_depth: no_id.coverage_depth,
+            consensus: no_id.consensus,
+            deletions: no_id.deletions,
+            ambiguous: no_id.ambiguous,
+            consensus_count: no_id.consensus_count,
+            consensus_avg_quality: no_id.consensus_avg_quality,
+            hmm_position: no_id.hmm_position,
+            run_id: no_id.run_id,
+            instrument: no_id.instrument,
+        }
+    }
 }
 
 /// Reads struct
@@ -316,6 +366,30 @@ pub struct NextcladeData {
     pub sample_id: Option<String>,
 }
 
+trait DeserializeWithSampleId: Sized {
+    type NoId: for<'de> Deserialize<'de>;
+
+    fn set_sample_id(no_id: Self::NoId, sample_id: &str) -> Self;
+
+    /// Read tab-delimited data and include the sample name
+    fn parse<R: Read>(
+        reader: R,
+        has_headers: bool,
+        sample_id: &str,
+    ) -> Result<Vec<Self>, csv::Error> {
+        let mut rdr = ReaderBuilder::new()
+            .has_headers(has_headers)
+            .delimiter(b'\t')
+            .from_reader(reader);
+
+        rdr.deserialize().process_results(|records| {
+            records
+                .map(|record| Self::set_sample_id(record, sample_id))
+                .collect::<Vec<_>>()
+        })
+    }
+}
+
 /////////////// Imp for the process_txt_with_sample_function ///////////////
 /// Define a trait for structs that have a `sample_id` field
 trait GetSampleId {
@@ -325,7 +399,7 @@ trait GetSampleId {
 // Implement the trait for CoverageData
 impl GetSampleId for CoverageData {
     fn set_sample_id(&mut self, sample_id: String) {
-        self.sample_id = Some(sample_id);
+        self.sample_id = sample_id;
     }
 }
 
@@ -507,8 +581,7 @@ pub fn coverage_data_collection(
                 let reader = BufReader::new(file);
 
                 // Read the data from the file and include the sample name
-                let mut records: Vec<CoverageData> =
-                    process_txt_with_sample(reader, true, &sample)?;
+                let mut records = CoverageData::parse(reader, true, &sample)?;
 
                 // If virus is "sc2-spike", replace position with hmm_position
                 if virus == "sc2-spike" {

--- a/src/io/write_parquet_files.rs
+++ b/src/io/write_parquet_files.rs
@@ -108,8 +108,7 @@ pub fn write_coverage_to_parquet(
     output_file: &str,
 ) -> Result<(), Box<dyn Error>> {
     // Convert values in struct to vector of values
-    let sample_ids_vec: Vec<Option<String>> =
-        extract_field(coverage_data, |item| item.sample_id.clone());
+    let sample_ids_vec = extract_field(coverage_data, |item| item.sample_id.clone());
     let ref_name_vec = extract_field(coverage_data, |item| item.reference_name.clone());
     let position_vec = extract_field(coverage_data, |item| item.position);
     let coverage_depth_vec = extract_field(coverage_data, |item| item.coverage_depth);

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -759,10 +759,7 @@ pub fn process_wgs_coverage_data<S: BuildHasher>(
 
     let mut cov_ref_lens: HashMap<(String, String), usize> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         *cov_ref_lens.entry(key).or_insert(0) += 1;
     }
 
@@ -783,10 +780,7 @@ pub fn process_wgs_coverage_data<S: BuildHasher>(
     // Calculate Median Coverage
     let mut coverage_vec_grouped: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for row in coverage_vec {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         coverage_vec_grouped
             .entry(key)
             .or_default()
@@ -837,10 +831,7 @@ pub fn process_position_coverage_data(
 
     let mut cov_sample_lens: HashMap<(String, String), usize> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         *cov_sample_lens.entry(key).or_insert(0) += 1;
     }
 
@@ -862,10 +853,7 @@ pub fn process_position_coverage_data(
     // Calculate median coverage
     let mut sample_med_cov_grouped: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
 
         sample_med_cov_grouped
             .entry(key)
@@ -1593,7 +1581,7 @@ pub fn transform_coverage_to_heatmap(
     };
 
     // Group by sample_id and reference_name, and calculate median coverage depth
-    let mut grouped_data: HashMap<(Option<String>, String), Vec<i32>> = HashMap::new();
+    let mut grouped_data: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for data in filtered_data {
         let key = (data.sample_id.clone(), data.reference_name.clone());
         grouped_data
@@ -1602,7 +1590,7 @@ pub fn transform_coverage_to_heatmap(
             .push(data.coverage_depth);
     }
 
-    let mut median_data: Vec<(Option<String>, String, i32)> = Vec::new();
+    let mut median_data: Vec<(String, String, i32)> = Vec::new();
     for ((sample_id, reference_name), depths) in grouped_data {
         let median_depth = calculate_median(&depths);
         median_data.push((sample_id, reference_name, median_depth));
@@ -1619,7 +1607,7 @@ pub fn transform_coverage_to_heatmap(
         };
 
         transformed_data.push(TransformedData {
-            sample_id,
+            sample_id: Some(sample_id),
             ref_id: segment,
             coverage_depth,
         });

--- a/src/utils/data_processing.rs
+++ b/src/utils/data_processing.rs
@@ -760,10 +760,7 @@ pub fn process_wgs_coverage_data<S: BuildHasher>(
 
     let mut cov_ref_lens: HashMap<(String, String), usize> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         *cov_ref_lens.entry(key).or_insert(0) += 1;
     }
 
@@ -784,10 +781,7 @@ pub fn process_wgs_coverage_data<S: BuildHasher>(
     // Calculate Median Coverage
     let mut coverage_vec_grouped: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for row in coverage_vec {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         coverage_vec_grouped
             .entry(key)
             .or_default()
@@ -838,10 +832,7 @@ pub fn process_position_coverage_data(
 
     let mut cov_sample_lens: HashMap<(String, String), usize> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
         *cov_sample_lens.entry(key).or_insert(0) += 1;
     }
 
@@ -863,10 +854,7 @@ pub fn process_position_coverage_data(
     // Calculate median coverage
     let mut sample_med_cov_grouped: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for row in &filtered_coverage {
-        let key = (
-            row.sample_id.clone().unwrap_or_default(),
-            row.reference_name.clone(),
-        );
+        let key = (row.sample_id.clone(), row.reference_name.clone());
 
         sample_med_cov_grouped
             .entry(key)
@@ -1599,7 +1587,7 @@ pub fn transform_coverage_to_heatmap(
     };
 
     // Group by sample_id and reference_name, and calculate median coverage depth
-    let mut grouped_data: HashMap<(Option<String>, String), Vec<i32>> = HashMap::new();
+    let mut grouped_data: HashMap<(String, String), Vec<i32>> = HashMap::new();
     for data in filtered_data {
         let key = (data.sample_id.clone(), data.reference_name.clone());
         grouped_data
@@ -1608,7 +1596,7 @@ pub fn transform_coverage_to_heatmap(
             .push(data.coverage_depth);
     }
 
-    let mut median_data: Vec<(Option<String>, String, i32)> = Vec::new();
+    let mut median_data: Vec<(String, String, i32)> = Vec::new();
     for ((sample_id, reference_name), depths) in grouped_data {
         let median_depth = calculate_median(&depths);
         median_data.push((sample_id, reference_name, median_depth));
@@ -1625,7 +1613,7 @@ pub fn transform_coverage_to_heatmap(
         };
 
         transformed_data.push(TransformedData {
-            sample_id,
+            sample_id: Some(sample_id),
             ref_id: segment,
             coverage_depth,
         });


### PR DESCRIPTION
This PR showcases a bit of the method I was mentioning here: https://github.com/CDCgov/mira-oxide/issues/87#issuecomment-4434575533. I made the change only for one struct as an example (`CoverageData`).

Essentially, the idea is there is a struct without the sample ID included which implements `Deserialize`. I have called this `CoverageDataNoId`. It is private, and doesn't get used except as an intermediate step during parsing.

We then have our full `CoverageData` which holds a non-optional `sample_id`. Instead of the `GetSampleId` trait and the `process_txt_with_sample` function, I propose a new trait:

```rust
trait DeserializeWithSampleId: Sized {
    type NoId: for<'de> Deserialize<'de>;

    fn set_sample_id(no_id: Self::NoId, sample_id: &str) -> Self;

    /// Read tab-delimited data and include the sample name
    fn parse<R: Read>(
        reader: R,
        has_headers: bool,
        sample_id: &str,
    ) -> Result<Vec<Self>, csv::Error> {
        let mut rdr = ReaderBuilder::new()
            .has_headers(has_headers)
            .delimiter(b'\t')
            .from_reader(reader);

        rdr.deserialize().process_results(|records| {
            records
                .map(|record| Self::set_sample_id(record, sample_id))
                .collect::<Vec<_>>()
        })
    }
}
```

`set_sample_id` is the same as before, but instead of mutating the struct, it converts the `NoId` type into the fully-parsed type. `parse` then provides the same functionality as `process_txt_with_sample`.

So, for example, we can write:

```
let mut records = CoverageData::parse(reader, true, &sample)?;
```

And that will give us a `Vec<CoverageData>`.