### PR TITLE
Update Zoe to v0.0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ plotly = "0.13.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10.0"
-zoe = { version = "0.0.28", default-features = false, features = [
+zoe = { version = "0.0.31", default-features = false, features = [
     "multiversion",
 ] }
 


### PR DESCRIPTION
This updates Zoe to the latest version. Among other fixes, it removes a soundness hole with `QualityScores`. Although this was not a problem in mira-oxide, it is worth updating to ensure future changes to mira-oxide do not encounter this bug.